### PR TITLE
fix: allow nested mocks and typing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{py,md,yml,toml}]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.flake8
+++ b/.flake8
@@ -13,4 +13,4 @@ extend-ignore =
 
 # configure flake8-docstrings
 # https://pypi.org/project/flake8-docstrings/
-docstring-convention = pep257
+docstring-convention = google

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,64 +3,64 @@ name: Continuous integration
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9"]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install poetry && poetry install
-      - name: Run tests
-        run: poetry run pytest
+    test:
+        name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest, macos-latest]
+                python-version: ["3.7", "3.8", "3.9"]
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install dependencies
+              run: pip install poetry && poetry install
+            - name: Run tests
+              run: poetry run pytest
 
-  check:
-    name: Lint and type checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-      - name: Install dependencies
-        run: pip install poetry && poetry install
-      - name: Format checks
-        run: poetry run black --check .
-      - name: Lint checks
-        run: poetry run flake8
-      - name: Type checks
-        run: poetry run mypy
+    check:
+        name: Lint and type checks
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: "3.8"
+            - name: Install dependencies
+              run: pip install poetry && poetry install
+            - name: Format checks
+              run: poetry run black --check .
+            - name: Lint checks
+              run: poetry run flake8
+            - name: Type checks
+              run: poetry run mypy
 
-  build:
-    name: Build assets and deploy on tags
-    runs-on: ubuntu-latest
-    needs: [test, check]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-      - name: Install dependencies
-        run: pip install poetry && poetry install
-      - name: Build artifacts
-        run: |
-          poetry build
-          poetry run mkdocs build
-      - if: startsWith(github.ref, 'refs/tags/v')
-        name: Deploy to PyPI and GitHub Pages
-        env:
-          USER_NAME: ${{ github.actor }}
-          USER_ID: ${{ github.event.sender.id }}
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          git config user.name "$USER_NAME (GitHub Actions)"
-          git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
-          poetry config pypi-token.pypi $PYPI_TOKEN
-          poetry publish
-          poetry run mkdocs gh-deploy
+    build:
+        name: Build assets and deploy on tags
+        runs-on: ubuntu-latest
+        needs: [test, check]
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: "3.8"
+            - name: Install dependencies
+              run: pip install poetry && poetry install
+            - name: Build artifacts
+              run: |
+                  poetry build
+                  poetry run mkdocs build
+            - if: startsWith(github.ref, 'refs/tags/v')
+              name: Deploy to PyPI and GitHub Pages
+              env:
+                  USER_NAME: ${{ github.actor }}
+                  USER_ID: ${{ github.event.sender.id }}
+                  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+              run: |
+                  git config user.name "$USER_NAME (GitHub Actions)"
+                  git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
+                  poetry config pypi-token.pypi $PYPI_TOKEN
+                  poetry publish
+                  poetry run mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 The Decoy library allows you to create, stub, and verify test double objects for your Python unit tests, so your tests are:
 
-- Less prone to insufficient tests due to unconditional stubbing
-- Covered by typechecking
-- Easier to fit into the Arrange-Act-Assert pattern
+-   Less prone to insufficient tests due to unconditional stubbing
+-   Covered by typechecking
+-   Easier to fit into the Arrange-Act-Assert pattern
 
 The Decoy API is heavily inspired by / stolen from the excellent [testdouble.js][] and [Mockito][] projects.
 
@@ -63,9 +63,9 @@ A stub is a an object used in a test that is pre-configured to act in a certain 
 
 By pre-configuring the stub with specific rehearsals, you get the following benefits:
 
-- Your test double will only return your mock value **if it is called correctly**
-- You avoid separate "set up mock return value" and "assert mock called correctly" steps
-- If you annotate your test double with an actual type, the rehearsal will fail typechecking if called incorrectly
+-   Your test double will only return your mock value **if it is called correctly**
+-   You avoid separate "set up mock return value" and "assert mock called correctly" steps
+-   If you annotate your test double with an actual type, the rehearsal will fail typechecking if called incorrectly
 
 ```python
 import pytest
@@ -99,13 +99,13 @@ If you're coming from `unittest.mock`, you're probably more used to calling your
 
 Verification of decoy calls after they have occurred be considered a last resort, because:
 
-- If you're calling a method/function to get its data, then you can more precisely describe that relationship using [stubbing](#stubbing)
-- Side-effects are harder to understand and maintain than pure functions, so in general you should try to side-effect sparingly
+-   If you're calling a method/function to get its data, then you can more precisely describe that relationship using [stubbing](#stubbing)
+-   Side-effects are harder to understand and maintain than pure functions, so in general you should try to side-effect sparingly
 
 Stubbing and verification of a decoy are **mutually exclusive** within a test. If you find yourself wanting to both stub and verify the same decoy, then one or more of these is true:
 
-- The assertions are redundant
-- The dependency is doing too much based on its input (e.g. side-effecting _and_ calculating complex data) and should be refactored
+-   The assertions are redundant
+-   The dependency is doing too much based on its input (e.g. side-effecting _and_ calculating complex data) and should be refactored
 
 ```python
 import pytest

--- a/decoy/matchers.py
+++ b/decoy/matchers.py
@@ -23,8 +23,7 @@ class _Anything:
 
 
 def Anything() -> Any:
-    """
-    Match anything except None.
+    """Match anything except None.
 
     Example:
         ```python
@@ -52,8 +51,7 @@ class _IsA:
 
 
 def IsA(match_type: type) -> Any:
-    """
-    Match anything that satisfies the passed in type.
+    """Match anything that satisfies the passed in type.
 
     Arguments:
         match_type: Type to match.
@@ -85,8 +83,7 @@ class _IsNot:
 
 
 def IsNot(value: object) -> Any:
-    """
-    Match anything that isn't the passed in value.
+    """Match anything that isn't the passed in value.
 
     Arguments:
         value: Value to check against.
@@ -120,8 +117,7 @@ class _StringMatching:
 
 
 def StringMatching(match: str) -> str:
-    """
-    Match any string matching the passed in pattern.
+    """Match any string matching the passed in pattern.
 
     Arguments:
         match: Pattern to check against; will be compiled into an re.Pattern.
@@ -163,8 +159,7 @@ class _ErrorMatching:
 
 
 def ErrorMatching(error: Type[Exception], match: Optional[str] = None) -> Exception:
-    """
-    Match any error matching an Exception type and optional message matcher.
+    """Match any error matching an Exception type and optional message matcher.
 
     Arguments:
         error: Exception type to match against.

--- a/decoy/mock.py
+++ b/decoy/mock.py
@@ -1,0 +1,29 @@
+"""Custom unittest.mock subclasses."""
+
+from mock import AsyncMock, MagicMock
+from typing import Any, Union
+
+
+class SyncDecoyMock(MagicMock):
+    """MagicMock variant where all child mocks use the parent side_effect."""
+
+    def _get_child_mock(self, **kwargs: Any) -> Any:
+        return super()._get_child_mock(**kwargs, side_effect=self.side_effect)
+
+
+class AsyncDecoyMock(AsyncMock):  # type: ignore[misc]
+    """AsyncMock variant where all child mocks use the parent side_effect."""
+
+    def _get_child_mock(self, **kwargs: Any) -> Any:
+        return super()._get_child_mock(**kwargs, side_effect=self.side_effect)
+
+
+DecoyMock = Union[SyncDecoyMock, AsyncDecoyMock]
+
+
+def create_decoy_mock(is_async: bool, **kwargs: Any) -> DecoyMock:
+    """Create a MagicMock or AsyncMock."""
+    if is_async is False:
+        return SyncDecoyMock(**kwargs)
+    else:
+        return AsyncDecoyMock(**kwargs)

--- a/decoy/registry.py
+++ b/decoy/registry.py
@@ -3,16 +3,16 @@ from mock import Mock
 from weakref import finalize, WeakValueDictionary
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from .mock import DecoyMock
 from .stub import Stub
 from .types import Call
 
 if TYPE_CHECKING:
-    DecoyMapType = WeakValueDictionary[int, Mock]
+    DecoyMapType = WeakValueDictionary[int, DecoyMock]
 
 
 class Registry:
-    """
-    Decoy and stub configuration registry.
+    """Decoy and stub configuration registry.
 
     The Registry collects weak-references to decoys created in order to
     automatically clean up stub configurations when a decoy goes out of scope.
@@ -23,7 +23,7 @@ class Registry:
         self._decoy_map: DecoyMapType = WeakValueDictionary()
         self._stub_map: Dict[int, List[Stub[Any]]] = {}
 
-    def register_decoy(self, decoy: Mock) -> int:
+    def register_decoy(self, decoy: DecoyMock) -> int:
         """Register a decoy for tracking."""
         decoy_id = id(decoy)
 

--- a/decoy/stub.py
+++ b/decoy/stub.py
@@ -13,8 +13,7 @@ class Stub(Generic[ReturnT]):
     _error: Optional[Exception]
 
     def __init__(self, rehearsal: Call) -> None:
-        """
-        Initialize the stub from a rehearsal call.
+        """Initialize the stub from a rehearsal call.
 
         Arguments:
             rehearsal: A call tuple to match against.
@@ -24,8 +23,7 @@ class Stub(Generic[ReturnT]):
         self._error = None
 
     def then_return(self, *values: ReturnT) -> None:
-        """
-        Set the stub's return value(s).
+        """Set the stub's return value(s).
 
         See [stubbing](/#stubbing) for more details.
 
@@ -38,8 +36,7 @@ class Stub(Generic[ReturnT]):
         self._values = deque(values)
 
     def then_raise(self, error: Exception) -> None:
-        """
-        Set the stub's error value.
+        """Set the stub's error value.
 
         See [stubbing](/#stubbing) for more details.
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -4,8 +4,8 @@ The Python testing world already has [unittest.mock][] for creating fakes, so wh
 
 The `MagicMock` class (and friends) provided by the Python standard library are great, which is why Decoy uses them under the hood. They are, however:
 
-- Not very opinionated in how they are used
-- Not able to adhere to type annotations of your actual interfaces
+-   Not very opinionated in how they are used
+-   Not able to adhere to type annotations of your actual interfaces
 
 At its core, Decoy wraps `MagicMock` with a more opinionated, strictly typed interface to encourage well written tests and, ultimately, well written source code.
 
@@ -17,9 +17,9 @@ Decoy is heavily influenced by and/or stolen from the [testdouble.js][] and [Moc
 
 If you have the time, you should check out:
 
-- Mockito Wiki - [How to write good tests](https://github.com/mockito/mockito/wiki/How-to-write-good-tests)
-- Test Double Wiki - [Discovery Testing](https://github.com/testdouble/contributing-tests/wiki/Discovery-Testing)
-- Test Double Wiki - [Test Double](https://github.com/testdouble/contributing-tests/wiki/Test-Double)
+-   Mockito Wiki - [How to write good tests](https://github.com/mockito/mockito/wiki/How-to-write-good-tests)
+-   Test Double Wiki - [Discovery Testing](https://github.com/testdouble/contributing-tests/wiki/Discovery-Testing)
+-   Test Double Wiki - [Test Double](https://github.com/testdouble/contributing-tests/wiki/Test-Double)
 
 [testdouble.js]: https://github.com/testdouble/testdouble.js
 [mockito]: https://site.mockito.org/
@@ -28,16 +28,16 @@ If you have the time, you should check out:
 
 A [stub][] is a specific type of test fake that:
 
-- Can be configured to respond in a certain way if given certain inputs
-- Will no-op if given output outside of its pre-configured specifications
+-   Can be configured to respond in a certain way if given certain inputs
+-   Will no-op if given output outside of its pre-configured specifications
 
 Stubs are great for simulating dependencies that provide data to or run calculations on input data for the code under test.
 
 For the following examples, let's assume:
 
-- We're testing a library to deal with `Book` objects
-- That library depends on a `Database` provider to store objects in a database
-- That library depends on a `Logger` interface to log access
+-   We're testing a library to deal with `Book` objects
+-   That library depends on a `Database` provider to store objects in a database
+-   That library depends on a `Logger` interface to log access
 
 [stub]: https://en.wikipedia.org/wiki/Test_stub
 
@@ -106,19 +106,19 @@ def test_get_book(mock_database: MagicMock, mock_book: Book) -> None:
 
 Both of these options have roughly the same upside and downsides:
 
-- Upside: `MagicMock` is part of the Python standard library
-- Downside: they're both a little difficult to read
-  - Option 1 separates the input checking from output value, and they appear in reverse chronological order (you define the dependency output before you define the input)
-  - Option 2 forces you to create a whole new function and assign it to the `side_effect` value
-- Downside: `MagicMock` is effectively `Any` typed
-  - `return_value` and `assert_called_with` are not typed according to the dependency's type definition
-  - A manual `side_effect`, if typed, needs to be manually typed, which may not match the actual dependency type definition
+-   Upside: `MagicMock` is part of the Python standard library
+-   Downside: they're both a little difficult to read
+    -   Option 1 separates the input checking from output value, and they appear in reverse chronological order (you define the dependency output before you define the input)
+    -   Option 2 forces you to create a whole new function and assign it to the `side_effect` value
+-   Downside: `MagicMock` is effectively `Any` typed
+    -   `return_value` and `assert_called_with` are not typed according to the dependency's type definition
+    -   A manual `side_effect`, if typed, needs to be manually typed, which may not match the actual dependency type definition
 
 Option 1 has another downside, specifically:
 
-- The mocked return value is unconditional
-  - If the assert step is wrong or accidentally skipped, the code-under-test is still fed the mock data
-  - This increases the likelihood of a false pass or insufficient test coverage
+-   The mocked return value is unconditional
+    -   If the assert step is wrong or accidentally skipped, the code-under-test is still fed the mock data
+    -   This increases the likelihood of a false pass or insufficient test coverage
 
 ### Stubbing with Decoy
 
@@ -163,12 +163,12 @@ def test_get_book(decoy: Decoy, mock_database: Database, mock_book: Book) -> Non
 
 Benefits to note over the vanilla `MagicMock` versions:
 
-- The rehearsal syntax for stub configuration is terse but very easy to read
-  - Inputs and outputs from the dependency are specified together
-  - You specify the inputs _before_ outputs, which can be easier to grok
-- The entire test fits neatly into "arrange", "act", and "assert" phases
-- Decoy casts test doubles as the actual types they are mimicking
-  - This means stub configuration arguments _and_ return values are type-checked
+-   The rehearsal syntax for stub configuration is terse but very easy to read
+    -   Inputs and outputs from the dependency are specified together
+    -   You specify the inputs _before_ outputs, which can be easier to grok
+-   The entire test fits neatly into "arrange", "act", and "assert" phases
+-   Decoy casts test doubles as the actual types they are mimicking
+    -   This means stub configuration arguments _and_ return values are type-checked
 
 ## Creating and Using a Spy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,26 +1,26 @@
 site_name: Decoy
 
 nav:
-  - User Guide: index.md
-  - why.md
-  - api.md
-  - contributing.md
+    - User Guide: index.md
+    - why.md
+    - api.md
+    - contributing.md
 
 theme:
-  name: "material"
-  palette:
-    scheme: preference
+    name: "material"
+    palette:
+        scheme: preference
 
 plugins:
-  - search
-  - mkdocstrings:
-      watch:
-        - decoy
-      handlers:
-        python:
-          rendering:
-            show_source: False
+    - search
+    - mkdocstrings:
+          watch:
+              - decoy
+          handlers:
+              python:
+                  rendering:
+                      show_source: False
 
 markdown_extensions:
-  - pymdownx.highlight
-  - pymdownx.superfences
+    - pymdownx.highlight
+    - pymdownx.superfences

--- a/poetry.lock
+++ b/poetry.lock
@@ -151,14 +151,14 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
-version = "3.0.0"
+version = "3.1.0"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
 
 [[package]]
 category = "dev"
@@ -703,8 +703,8 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.0.0-py2.py3-none-any.whl", hash = "sha256:fc3b3f9697703d3833d2803162d60cbe8b9f57b5da5e6496ac81e3cb82bd8d9c"},
-    {file = "importlib_metadata-3.0.0.tar.gz", hash = "sha256:d582eb5c35b2f16c78e365e0f89e369f36af38fdaad0146208aa973c693ba247"},
+    {file = "importlib_metadata-3.1.0-py2.py3-none-any.whl", hash = "sha256:590690d61efdd716ff82c39ca9a9d4209252adfe288a4b5721181050acbd4175"},
+    {file = "importlib_metadata-3.1.0.tar.gz", hash = "sha256:d9b8a46a0885337627a6430db287176970fff18ad421becec1d64cfc763c2099"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -515,6 +515,20 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 category = "dev"
+description = "Pytest support for asyncio."
+name = "pytest-asyncio"
+optional = false
+python-versions = ">= 3.5"
+version = "0.14.0"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
+
+[[package]]
+category = "dev"
 description = "Local continuous test runner with pytest and watchdog."
 name = "pytest-watch"
 optional = false
@@ -651,7 +665,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "907b2920f3f8cdbe8c5777fe52725bd21b1c9d3b37135dbf48457f277349aea7"
+content-hash = "85d940ae0ced9f2e661912b5a096b6ccbe0b9d9f6e4978d0a01fb5040de56b2e"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -857,6 +871,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
     {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
+    {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
 ]
 pytest-watch = [
     {file = "pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ mkdocstrings = "^0.13.6"
 mypy = "^0.790"
 pytest = "^6.1.2"
 pytest-watch = "^4.2.0"
+pytest-asyncio = "^0.14.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,13 @@ repository = "https://github.com/mcous/decoy"
 homepage = "https://mike.cousins.io/decoy/"
 documentation = "https://mike.cousins.io/decoy/"
 
-include = [
-  "LICENSE"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Testing :: Mocking",
+    "Typing :: Typed",
 ]
 
 [tool.poetry.dependencies]

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,6 +12,39 @@ class SomeClass:
         """Get the bar bool based on a few inputs."""
         ...
 
+    def do_the_thing(self, flag: bool) -> None:
+        """Perform a side-effect without a return value."""
+        ...
+
+
+class SomeNestedClass:
+    """Nested testing class."""
+
+    def foo(self, val: str) -> str:
+        """Get the foo string."""
+        ...
+
+    @property
+    def child(self) -> SomeClass:
+        """Get the child instance."""
+        ...
+
+
+class SomeAsyncClass:
+    """Async testing class."""
+
+    async def foo(self, val: str) -> str:
+        """Get the foo string."""
+        ...
+
+    async def bar(self, a: int, b: float, c: str) -> bool:
+        """Get the bar bool based on a few inputs."""
+        ...
+
+    async def do_the_thing(self, flag: bool) -> None:
+        """Perform a side-effect without a return value."""
+        ...
+
 
 def some_func(val: str) -> str:
     """Test function."""

--- a/tests/test_decoy.py
+++ b/tests/test_decoy.py
@@ -3,15 +3,24 @@ from mock import MagicMock, AsyncMock
 from typing import Callable
 
 from decoy import Decoy
-from .common import SomeClass, some_func
+from .common import SomeClass, SomeNestedClass, some_func
 
 
 def test_decoy_creates_magicmock(decoy: Decoy) -> None:
     """It should be able to create a MagicMock from a class."""
-    stub = decoy.create_decoy(spec=SomeClass, is_async=False)
+    stub = decoy.create_decoy(spec=SomeClass)
 
     assert isinstance(stub, MagicMock)
     assert isinstance(stub, SomeClass)
+
+
+def test_decoy_creates_nested_magicmock(decoy: Decoy) -> None:
+    """It should be able to create a nested MagicMock from a class."""
+    stub = decoy.create_decoy(spec=SomeNestedClass)
+
+    assert isinstance(stub, MagicMock)
+    assert isinstance(stub, SomeNestedClass)
+    assert isinstance(stub.child, MagicMock)
 
 
 def test_decoy_creates_asyncmock(decoy: Decoy) -> None:
@@ -56,3 +65,14 @@ def test_decoy_methods_return_none(decoy: Decoy) -> None:
 
     assert stub.foo("hello") is None
     assert stub.bar(1, 2.0, "3") is None
+
+
+def test_decoy_nested_methods_return_none(decoy: Decoy) -> None:
+    """Decoy classes should return None by default."""
+    stub = decoy.create_decoy(spec=SomeNestedClass)
+
+    print(dir(SomeNestedClass))
+    print(dir(stub))
+
+    assert stub.foo("hello") is None
+    assert stub.child.bar(1, 2.0, "3") is None

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2,7 +2,7 @@
 import pytest
 
 from decoy import Decoy, matchers
-from .common import SomeClass, some_func
+from .common import SomeClass, SomeNestedClass, some_func
 
 
 def test_call_function_then_verify(decoy: Decoy) -> None:
@@ -51,3 +51,29 @@ def test_verify_with_matcher(decoy: Decoy) -> None:
 
     with pytest.raises(AssertionError):
         decoy.verify(stub(matchers.StringMatching("^ello")))
+
+
+def test_call_nested_method_then_verify(decoy: Decoy) -> None:
+    """It should be able to verify a past nested method call."""
+    stub = decoy.create_decoy(spec=SomeNestedClass)
+
+    stub.child.foo("hello")
+    stub.child.bar(0, 1.0, "2")
+
+    decoy.verify(stub.child.foo("hello"))
+    decoy.verify(stub.child.bar(0, 1.0, "2"))
+
+    with pytest.raises(AssertionError):
+        decoy.verify(stub.foo("fizzbuzz"))
+
+
+def test_call_no_return_method_then_verify(decoy: Decoy) -> None:
+    """It should be able to verify a past void method call."""
+    stub = decoy.create_decoy(spec=SomeClass)
+
+    stub.do_the_thing(True)
+
+    decoy.verify(stub.do_the_thing(True))  # type: ignore[func-returns-value]
+
+    with pytest.raises(AssertionError):
+        decoy.verify(stub.do_the_thing(False))  # type: ignore[func-returns-value]


### PR DESCRIPTION
This PR:

- Ensures mocks can be nested
- Adds missing `py.typed` file that was preventing mypy from picking up types in the end-user environment

Since I'm making changes, it also includes the following fixes:

- Fix docs indent problems by always using 4-space tabs in Markdown
- Add missing classifiers to pyproject.toml
- Ensure CI can always deploy docs using `--force`