### PR TITLE
feat: add mypy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ pip install decoy
 poetry add --dev decoy
 ```
 
-## Usage
-
-### Setup
+## Setup
 
 You'll want to create a test fixture to reset Decoy state between each test run. In [pytest][], you can do this by using a fixture to create a new Decoy instance for every test.
 
@@ -56,6 +54,25 @@ def decoy() -> Decoy:
 Why is this important? The `Decoy` container tracks every fake that is created during a test so that you can define assertions using fully-typed rehearsals of your test double. It's important to wipe this slate clean for every test so you don't leak memory or have any state preservation between tests.
 
 [pytest]: https://docs.pytest.org/
+
+### Mypy Setup
+
+Decoy's rehearsal syntax can be a bit confusing to [mypy][] if the mock in question is supposed to return `None`. Normally, [mypy will complain][] if you try to use a `None`-returning expression as a value, because this is almost always a mistake.
+
+In Decoy, however, it's an intentional part of the API and _not_ a mistake. To suppress these errors, Decoy provides a mypy plugin that you should add to your configuration file:
+
+```ini
+# mypi.ini
+
+# ...
+plugins = decoy.mypy
+# ...
+```
+
+[mypy]: https://mypy.readthedocs.io/
+[mypy will complain]: https://mypy.readthedocs.io/en/stable/error_code_list.html#check-that-called-function-returns-a-value-func-returns-value
+
+## Usage
 
 ### Stubbing
 
@@ -126,6 +143,16 @@ Stubbing and verification of a decoy are **mutually exclusive** within a test. I
 
 -   The assertions are redundant
 -   The dependency is doing too much based on its input (e.g. side-effecting _and_ calculating complex data) and should be refactored
+
+### Usage with async/await
+
+Decoy supports async/await out of the box! Pass your async function or class with async methods to `spec` in `decoy.create_decoy_func` or `decoy.create_decoy`, respectively, and Decoy will figure out the rest.
+
+When writing rehearsals on async functions and methods, remember to include the `await` with your rehearsal call:
+
+```py
+decoy.when(await mock_db.get_by_id("some-id")).then_return(mock_item)
+```
 
 ### Matchers
 

--- a/decoy/mypy.py
+++ b/decoy/mypy.py
@@ -1,0 +1,39 @@
+"""Decoy mypy plugin."""
+from typing import Callable, Optional, Type as ClassType
+
+from mypy.errorcodes import FUNC_RETURNS_VALUE
+from mypy.plugin import Plugin, MethodContext
+from mypy.types import Type
+
+
+class DecoyPlugin(Plugin):
+    """A mypy plugin to remove otherwise valid errors from rehearsals."""
+
+    def get_method_hook(
+        self, fullname: str
+    ) -> Optional[Callable[[MethodContext], Type]]:
+        """Remove any func-returns-value errors inside `when` or `verify` calls."""
+        if fullname in {"decoy.Decoy.verify", "decoy.Decoy.when"}:
+            return self._handle_decoy_call
+
+        return None
+
+    def _handle_decoy_call(self, ctx: MethodContext) -> Type:
+        errors_list = ctx.api.msg.errors.error_info_map.get(ctx.api.path, [])
+        rehearsal_call_args = ctx.args[0] if len(ctx.args) > 0 else []
+
+        for err in errors_list:
+            for arg in rehearsal_call_args:
+                if (
+                    err.code == FUNC_RETURNS_VALUE
+                    and arg.line == err.line
+                    and arg.column == err.column
+                ):
+                    errors_list.remove(err)
+
+        return ctx.default_return_type
+
+
+def plugin(version: str) -> ClassType[DecoyPlugin]:
+    """Get the DecoyPlugin class definition."""
+    return DecoyPlugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,10 @@
 site_name: Decoy
 site_description: "Opinionated, typed stubbing and verification library for Python."
+site_author: "Mike Cousins"
 site_url: "https://mike.cousins.io/decoy/"
 repo_url: "https://github.com/mcous/decoy"
 repo_name: "mcous/decoy"
+edit_uri: "blob/main/docs/"
 
 nav:
     - User Guide: index.md
@@ -14,6 +16,8 @@ theme:
     name: "material"
     palette:
         scheme: preference
+    features:
+        - navigation.instant
 
 plugins:
     - search

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,4 @@
 files = decoy,tests
 strict = True
 show_error_codes = True
+plugins = decoy.mypy

--- a/poetry.lock
+++ b/poetry.lock
@@ -95,6 +95,14 @@ version = "0.4.4"
 
 [[package]]
 category = "dev"
+description = "Decorators for Humans"
+name = "decorator"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "4.4.2"
+
+[[package]]
+category = "dev"
 description = "execnet: rapid multi-Python deployment"
 name = "execnet"
 optional = false
@@ -166,14 +174,14 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
+version = "3.1.1"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 category = "dev"
@@ -482,6 +490,14 @@ version = "2.4.7"
 
 [[package]]
 category = "dev"
+description = "Mustache for Python"
+name = "pystache"
+optional = false
+python-versions = "*"
+version = "0.5.4"
+
+[[package]]
+category = "dev"
 description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
@@ -531,6 +547,21 @@ version = "1.3.0"
 [package.dependencies]
 py = "*"
 pytest = ">=3.10"
+
+[[package]]
+category = "dev"
+description = "pytest plugin for writing tests for mypy plugins"
+name = "pytest-mypy-plugins"
+optional = false
+python-versions = ">=3.6"
+version = "1.6.1"
+
+[package.dependencies]
+decorator = "*"
+mypy = ">=0.790"
+pystache = ">=0.5.4"
+pytest = ">=6.0.0"
+pyyaml = "*"
 
 [[package]]
 category = "dev"
@@ -659,7 +690,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "d035493bcb82eba8c4e65d16ef5165c0702ab3c23c4babcb0917326b1c55721b"
+content-hash = "5349aa0d10450f120d0eac9a74d79eac97c4f038196e9775db8e6305b7f8b9fd"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -696,6 +727,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+decorator = [
+    {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
+    {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
 execnet = [
     {file = "execnet-1.7.1-py2.py3-none-any.whl", hash = "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"},
     {file = "execnet-1.7.1.tar.gz", hash = "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50"},
@@ -716,8 +751,8 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.1.0-py2.py3-none-any.whl", hash = "sha256:590690d61efdd716ff82c39ca9a9d4209252adfe288a4b5721181050acbd4175"},
-    {file = "importlib_metadata-3.1.0.tar.gz", hash = "sha256:d9b8a46a0885337627a6430db287176970fff18ad421becec1d64cfc763c2099"},
+    {file = "importlib_metadata-3.1.1-py3-none-any.whl", hash = "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013"},
+    {file = "importlib_metadata-3.1.1.tar.gz", hash = "sha256:b0c2d3b226157ae4517d9625decf63591461c66b3a808c2666d538946519d170"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -860,6 +895,9 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
+pystache = [
+    {file = "pystache-0.5.4.tar.gz", hash = "sha256:f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a"},
+]
 pytest = [
     {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
     {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
@@ -871,6 +909,10 @@ pytest-asyncio = [
 pytest-forked = [
     {file = "pytest-forked-1.3.0.tar.gz", hash = "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca"},
     {file = "pytest_forked-1.3.0-py2.py3-none-any.whl", hash = "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"},
+]
+pytest-mypy-plugins = [
+    {file = "pytest-mypy-plugins-1.6.1.tar.gz", hash = "sha256:f73986d4d78057f259518b81b019896985b19a698ce41deb6996ec73c3d7fcc6"},
+    {file = "pytest_mypy_plugins-1.6.1-py3-none-any.whl", hash = "sha256:b7f9c736f498a520c42ab393069b6e272036c2e4409d777403566e353743d603"},
 ]
 pytest-xdist = [
     {file = "pytest-xdist-2.1.0.tar.gz", hash = "sha256:82d938f1a24186520e2d9d3a64ef7d9ac7ecdf1a0659e095d18e596b8cbd0672"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ pytest-mypy-plugins = "^1.6.1"
 pytest-xdist = "^2.1.0"
 
 [tool.pytest.ini_options]
-addopts = "--color=yes"
+addopts = "--color=yes --mypy-ini-file=mypy.ini"
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ mkdocstrings = "^0.13.6"
 mypy = "^0.790"
 pytest = "^6.1.2"
 pytest-asyncio = "^0.14.0"
+pytest-mypy-plugins = "^1.6.1"
 pytest-xdist = "^2.1.0"
 
 [tool.pytest.ini_options]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -73,7 +73,7 @@ def test_call_no_return_method_then_verify(decoy: Decoy) -> None:
 
     stub.do_the_thing(True)
 
-    decoy.verify(stub.do_the_thing(True))  # type: ignore[func-returns-value]
+    decoy.verify(stub.do_the_thing(True))
 
     with pytest.raises(AssertionError):
-        decoy.verify(stub.do_the_thing(False))  # type: ignore[func-returns-value]
+        decoy.verify(stub.do_the_thing(False))

--- a/tests/typing/test_mypy_plugin.yml
+++ b/tests/typing/test_mypy_plugin.yml
@@ -1,17 +1,15 @@
 # mypy plugin tests
 
 - case: does_not_suppress_func_returns_value
-  mypy_config: plugins = decoy.mypy
   main: |
       def noop() -> None:
           pass
 
       value = noop()
   out: |
-      main:4: error: "noop" does not return a value
+      main:4: error: "noop" does not return a value  [func-returns-value]
 
 - case: suppresses_func_returns_value_in_when
-  mypy_config: plugins = decoy.mypy
   main: |
       from decoy import Decoy
 
@@ -22,7 +20,6 @@
       stub = decoy.when(noop())
 
 - case: suppresses_func_returns_value_in_verify
-  mypy_config: plugins = decoy.mypy
   main: |
       from decoy import Decoy
 
@@ -33,7 +30,6 @@
       decoy.verify(noop())
 
 - case: does_not_suppress_other_errors
-  mypy_config: plugins = decoy.mypy
   main: |
       from decoy import Decoy
 
@@ -43,4 +39,4 @@
       decoy = Decoy()
       stub = decoy.when(do_thing("hello"))
   out: |
-      main:7: error: Too many arguments for "do_thing"
+      main:7: error: Too many arguments for "do_thing"  [call-arg]

--- a/tests/typing/test_mypy_plugin.yml
+++ b/tests/typing/test_mypy_plugin.yml
@@ -1,0 +1,46 @@
+# mypy plugin tests
+
+- case: does_not_suppress_func_returns_value
+  mypy_config: plugins = decoy.mypy
+  main: |
+      def noop() -> None:
+          pass
+
+      value = noop()
+  out: |
+      main:4: error: "noop" does not return a value
+
+- case: suppresses_func_returns_value_in_when
+  mypy_config: plugins = decoy.mypy
+  main: |
+      from decoy import Decoy
+
+      def noop() -> None:
+          pass
+
+      decoy = Decoy()
+      stub = decoy.when(noop())
+
+- case: suppresses_func_returns_value_in_verify
+  mypy_config: plugins = decoy.mypy
+  main: |
+      from decoy import Decoy
+
+      def noop() -> None:
+          pass
+
+      decoy = Decoy()
+      decoy.verify(noop())
+
+- case: does_not_suppress_other_errors
+  mypy_config: plugins = decoy.mypy
+  main: |
+      from decoy import Decoy
+
+      def do_thing() -> int:
+          return 42
+
+      decoy = Decoy()
+      stub = decoy.when(do_thing("hello"))
+  out: |
+      main:7: error: Too many arguments for "do_thing"

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -42,7 +42,7 @@
       decoy.when(fake.do_thing("hello")).then_return(42)
       decoy.when(fake.do_thing("goodbye")).then_return("wrong-type")
   out: |
-      main:11: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"
+      main:11: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"  [arg-type]
 
 - case: function_stub_mimics_return_type
   main: |
@@ -57,4 +57,4 @@
       decoy.when(fake("hello")).then_return(42)
       decoy.when(fake("goodbye")).then_return("wrong-type")
   out: |
-      main:10: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"
+      main:10: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"  [arg-type]

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -1,0 +1,60 @@
+# typing tests
+
+- case: class_decoy_mimics_type
+  main: |
+      from decoy import Decoy
+
+      class Dependency():
+          def do_thing(self, input: str) -> int:
+              return 42
+
+
+      decoy = Decoy()
+      fake = decoy.create_decoy(spec=Dependency)
+      reveal_type(fake)
+  out: |
+      main:10: note: Revealed type is 'main.Dependency*'
+
+- case: function_decoy_mimics_type
+  main: |
+      from decoy import Decoy
+
+      def do_thing(input: str) -> int:
+          return 42
+
+      decoy = Decoy()
+      fake = decoy.create_decoy_func(spec=do_thing)
+      reveal_type(fake)
+  out: |
+      main:8: note: Revealed type is 'def (input: builtins.str) -> builtins.int'
+
+- case: class_stub_mimics_return_type
+  main: |
+      from decoy import Decoy
+
+      class Dependency():
+          def do_thing(self, input: str) -> int:
+              return 42
+
+      decoy = Decoy()
+      fake = decoy.create_decoy(spec=Dependency)
+
+      decoy.when(fake.do_thing("hello")).then_return(42)
+      decoy.when(fake.do_thing("goodbye")).then_return("wrong-type")
+  out: |
+      main:11: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"
+
+- case: function_stub_mimics_return_type
+  main: |
+      from decoy import Decoy
+
+      def do_thing(input: str) -> int:
+          return 42
+
+      decoy = Decoy()
+      fake = decoy.create_decoy_func(spec=do_thing)
+
+      decoy.when(fake("hello")).then_return(42)
+      decoy.when(fake("goodbye")).then_return("wrong-type")
+  out: |
+      main:10: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -8,12 +8,11 @@
           def do_thing(self, input: str) -> int:
               return 42
 
-
       decoy = Decoy()
       fake = decoy.create_decoy(spec=Dependency)
       reveal_type(fake)
   out: |
-      main:10: note: Revealed type is 'main.Dependency*'
+      main:9: note: Revealed type is 'main.Dependency*'
 
 - case: function_decoy_mimics_type
   main: |


### PR DESCRIPTION
Closes #5. See ticket for details.

In addition to the mypy plugin to suppress spurious `func-returns-value` errors on rehearsals, this PR also adds...

- Tests for that plugin
- Tests for the spy and stub typing

...via the [pytest-mypy-plugins](https://github.com/typeddjango/pytest-mypy-plugins) library