### PR TITLE
feat(verify): add proper assertion messages

### DIFF
--- a/decoy/matchers.py
+++ b/decoy/matchers.py
@@ -104,7 +104,7 @@ class _IsNot:
 
     def __repr__(self) -> str:
         """Return a string representation of the matcher."""
-        return f"<IsNot {self._reject_value}>"
+        return f"<IsNot {repr(self._reject_value)}>"
 
 
 def IsNot(value: object) -> Any:
@@ -138,7 +138,7 @@ class _StringMatching:
 
     def __repr__(self) -> str:
         """Return a string representation of the matcher."""
-        return f"<StringMatching {self._pattern.pattern}>"
+        return f"<StringMatching {repr(self._pattern.pattern)}>"
 
 
 def StringMatching(match: str) -> str:

--- a/decoy/spy.py
+++ b/decoy/spy.py
@@ -6,7 +6,7 @@ Classes in this module are heavily inspired by the
 from __future__ import annotations
 from dataclasses import dataclass
 from inspect import isclass, iscoroutinefunction
-from typing import get_type_hints, Any, Callable, Dict, Optional, Tuple
+from typing import get_type_hints, Any, Callable, Dict, Optional, Tuple, Type
 
 
 @dataclass(frozen=True)
@@ -20,8 +20,20 @@ class SpyCall:
     """
 
     spy_id: int
+    spy_name: str
     args: Tuple[Any, ...]
     kwargs: Dict[str, Any]
+
+    def __str__(self) -> str:
+        """Stringify the call to something human readable.
+
+        `SpyCall(spy_id=42, spy_name="name", args=(1,), kwargs={"foo": False})`
+        would stringify as `"name(1, foo=False)"`
+        """
+        args_list = [repr(arg) for arg in self.args]
+        kwargs_list = [f"{key}={repr(val)}" for key, val in self.kwargs.items()]
+
+        return f"{self.spy_name}({', '.join(args_list + kwargs_list)})"
 
 
 CallHandler = Callable[[SpyCall], Any]
@@ -34,8 +46,14 @@ class BaseSpy:
     - Lazily constructs child spies when an attribute is accessed
     """
 
-    def __init__(self, handle_call: CallHandler, spec: Optional[Any] = None) -> None:
+    def __init__(
+        self,
+        handle_call: CallHandler,
+        spec: Optional[Any] = None,
+        name: Optional[str] = None,
+    ) -> None:
         """Initialize a BaseSpy from a call handler and an optional spec object."""
+        self._name = name or (spec.__name__ if spec is not None else "spy")
         self._spec = spec
         self._handle_call: CallHandler = handle_call
         self._spy_children: Dict[str, BaseSpy] = {}
@@ -73,6 +91,7 @@ class BaseSpy:
         spy = create_spy(
             handle_call=self._handle_call,
             spec=child_spec,
+            name=f"{self._name}.{name}",
         )
 
         self._spy_children[name] = spy
@@ -85,28 +104,31 @@ class Spy(BaseSpy):
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Handle a call to the spy."""
-        return self._handle_call(SpyCall(id(self), args, kwargs))
+        return self._handle_call(SpyCall(id(self), self._name, args, kwargs))
 
 
-class AsyncSpy(Spy):
+class AsyncSpy(BaseSpy):
     """An object that records all async. calls made to itself and its children."""
 
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Handle a call to the spy asynchronously."""
-        return self._handle_call(SpyCall(id(self), args, kwargs))
+        return self._handle_call(SpyCall(id(self), self._name, args, kwargs))
 
 
 def create_spy(
     handle_call: CallHandler,
     spec: Optional[Any] = None,
     is_async: bool = False,
+    name: Optional[str] = None,
 ) -> Any:
     """Create a Spy from a spec.
 
     Functions and classes passed to `spec` will be inspected (and have any type
     annotations inspected) to ensure `AsyncSpy`'s are returned where necessary.
     """
-    if iscoroutinefunction(spec) or is_async is True:
-        return AsyncSpy(handle_call)
+    _SpyCls: Type[BaseSpy] = Spy
 
-    return Spy(handle_call=handle_call, spec=spec)
+    if iscoroutinefunction(spec) or is_async is True:
+        _SpyCls = AsyncSpy
+
+    return _SpyCls(handle_call=handle_call, spec=spec, name=name)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,66 +1,63 @@
 [[package]]
-category = "dev"
-description = "apipkg: namespace control and lazy-import mechanism"
 name = "apipkg"
+version = "1.5"
+description = "apipkg: namespace control and lazy-import mechanism"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.5"
 
 [[package]]
-category = "dev"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.4"
 
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "dev"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
-description = "Screen-scraping library"
 name = "beautifulsoup4"
+version = "4.9.3"
+description = "Screen-scraping library"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "4.9.3"
 
 [package.dependencies]
-[package.dependencies.soupsieve]
-python = ">=3.0"
-version = ">1.2"
+soupsieve = {version = ">1.2", markers = "python_version >= \"3.0\""}
 
 [package.extras]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-category = "dev"
-description = "The uncompromising code formatter."
 name = "black"
+version = "20.8b1"
+description = "The uncompromising code formatter."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "20.8b1"
 
 [package.dependencies]
 appdirs = "*"
@@ -77,37 +74,36 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "dev"
-description = "Composable command line interface toolkit"
 name = "click"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.2"
-
-[[package]]
+description = "Composable command line interface toolkit"
 category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
-name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.4"
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
 category = "dev"
-description = "Decorators for Humans"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "decorator"
+version = "4.4.2"
+description = "Decorators for Humans"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.4.2"
 
 [[package]]
-category = "dev"
-description = "execnet: rapid multi-Python deployment"
 name = "execnet"
+version = "1.7.1"
+description = "execnet: rapid multi-Python deployment"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.7.1"
 
 [package.dependencies]
 apipkg = ">=1.4"
@@ -116,88 +112,81 @@ apipkg = ">=1.4"
 testing = ["pre-commit"]
 
 [[package]]
-category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.4"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
 [[package]]
-category = "dev"
-description = "Flake8 Type Annotation Checks"
 name = "flake8-annotations"
+version = "2.4.1"
+description = "Flake8 Type Annotation Checks"
+category = "dev"
 optional = false
 python-versions = ">=3.6.1,<4.0.0"
-version = "2.4.1"
 
 [package.dependencies]
 flake8 = ">=3.7,<3.9"
-
-[package.dependencies.typed-ast]
-python = "<3.8"
-version = ">=1.4,<2.0"
+typed-ast = {version = ">=1.4,<2.0", markers = "python_version < \"3.8\""}
 
 [[package]]
-category = "dev"
-description = "Extension for flake8 which uses pydocstyle to check docstrings"
 name = "flake8-docstrings"
+version = "1.5.0"
+description = "Extension for flake8 which uses pydocstyle to check docstrings"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.5.0"
 
 [package.dependencies]
 flake8 = ">=3"
 pydocstyle = ">=2.1"
 
 [[package]]
-category = "dev"
-description = "Clean single-source support for Python 3 and 2"
 name = "future"
+version = "0.18.2"
+description = "Clean single-source support for Python 3 and 2"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.18.2"
 
 [[package]]
-category = "dev"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "3.1.1"
+description = "Read metadata from Python packages"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.1"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.1.1"
 
 [[package]]
-category = "dev"
-description = "A very fast and expressive template engine."
 name = "jinja2"
+version = "2.11.2"
+description = "A very fast and expressive template engine."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.11.2"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -206,134 +195,121 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
-category = "dev"
-description = "Lightweight pipelining: using Python functions as pipeline jobs."
-marker = "python_version > \"2.7\""
 name = "joblib"
+version = "0.17.0"
+description = "Lightweight pipelining: using Python functions as pipeline jobs."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "0.17.0"
 
 [[package]]
-category = "dev"
-description = "Python LiveReload is an awesome tool for web developers"
 name = "livereload"
+version = "2.6.3"
+description = "Python LiveReload is an awesome tool for web developers"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2.6.3"
 
 [package.dependencies]
 six = "*"
-
-[package.dependencies.tornado]
-python = ">=2.8"
-version = "*"
+tornado = {version = "*", markers = "python_version > \"2.7\""}
 
 [[package]]
-category = "dev"
-description = "A Python implementation of Lunr.js"
 name = "lunr"
+version = "0.5.8"
+description = "A Python implementation of Lunr.js"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.5.8"
 
 [package.dependencies]
 future = ">=0.16.0"
+nltk = {version = ">=3.2.5", optional = true, markers = "python_version > \"2.7\" and extra == \"languages\""}
 six = ">=1.11.0"
-
-[package.dependencies.nltk]
-optional = true
-python = ">=2.8"
-version = ">=3.2.5"
 
 [package.extras]
 languages = ["nltk (>=3.2.5,<3.5)", "nltk (>=3.2.5)"]
 
 [[package]]
-category = "dev"
-description = "Python implementation of Markdown."
 name = "markdown"
+version = "3.3.3"
+description = "Python implementation of Markdown."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.3"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 testing = ["coverage", "pyyaml"]
 
 [[package]]
-category = "dev"
-description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
+version = "1.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.1.1"
 
 [[package]]
-category = "dev"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "dev"
-description = "Project documentation with Markdown."
 name = "mkdocs"
+version = "1.1.2"
+description = "Project documentation with Markdown."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.1.2"
 
 [package.dependencies]
+click = ">=3.3"
 Jinja2 = ">=2.10.1"
+livereload = ">=2.5.1"
+lunr = {version = "0.5.8", extras = ["languages"]}
 Markdown = ">=3.2.1"
 PyYAML = ">=3.10"
-click = ">=3.3"
-livereload = ">=2.5.1"
 tornado = ">=5.0"
 
-[package.dependencies.lunr]
-extras = ["languages"]
-version = "0.5.8"
-
 [[package]]
-category = "dev"
-description = "A Material Design theme for MkDocs"
 name = "mkdocs-material"
+version = "6.1.6"
+description = "A Material Design theme for MkDocs"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "6.1.6"
 
 [package.dependencies]
-Pygments = ">=2.4"
 markdown = ">=3.2"
 mkdocs = ">=1.1"
 mkdocs-material-extensions = ">=1.0"
+Pygments = ">=2.4"
 pymdown-extensions = ">=7.0"
 
 [[package]]
-category = "dev"
-description = "Extension pack for Python Markdown."
 name = "mkdocs-material-extensions"
+version = "1.0.1"
+description = "Extension pack for Python Markdown."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.0.1"
 
 [package.dependencies]
 mkdocs-material = ">=5.0.0"
 
 [[package]]
-category = "dev"
-description = "Automatic documentation from sources, for MkDocs."
 name = "mkdocstrings"
+version = "0.13.6"
+description = "Automatic documentation from sources, for MkDocs."
+category = "dev"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.13.6"
 
 [package.dependencies]
 beautifulsoup4 = ">=4.8.2,<5.0.0"
@@ -345,12 +321,12 @@ pytkdocs = ">=0.2.0,<0.10.0"
 tests = ["coverage (>=5.2.1,<6.0.0)", "invoke (>=1.4.1,<2.0.0)", "mkdocs-material (>=5.5.12,<6.0.0)", "mypy (>=0.782,<0.783)", "pytest (>=6.0.1,<7.0.0)", "pytest-cov (>=2.10.1,<3.0.0)", "pytest-randomly (>=3.4.1,<4.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=2.1.0,<3.0.0)"]
 
 [[package]]
-category = "dev"
-description = "Optional static typing for Python"
 name = "mypy"
+version = "0.790"
+description = "Optional static typing for Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "0.790"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -361,21 +337,20 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-category = "dev"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
 name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.4.3"
 
 [[package]]
-category = "dev"
-description = "Natural Language Toolkit"
-marker = "python_version > \"2.7\""
 name = "nltk"
+version = "3.5"
+description = "Natural Language Toolkit"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "3.5"
 
 [package.dependencies]
 click = "*"
@@ -392,143 +367,138 @@ tgrep = ["pyparsing"]
 twitter = ["twython"]
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.7"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.7"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
-category = "dev"
-description = "Utility library for gitignore style pattern matching of file paths."
 name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.1"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.9.0"
-
-[[package]]
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
-description = "Python style guide checker"
-name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.6.0"
 
 [[package]]
+name = "pycodestyle"
+version = "2.6.0"
+description = "Python style guide checker"
 category = "dev"
-description = "Python docstring style checker"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pydocstyle"
+version = "5.1.1"
+description = "Python docstring style checker"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "5.1.1"
 
 [package.dependencies]
 snowballstemmer = "*"
 
 [[package]]
-category = "dev"
-description = "passive checker of Python programs"
 name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
-category = "dev"
-description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
+version = "2.7.2"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.2"
 
 [[package]]
-category = "dev"
-description = "Extension pack for Python Markdown."
 name = "pymdown-extensions"
+version = "8.0.1"
+description = "Extension pack for Python Markdown."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "8.0.1"
 
 [package.dependencies]
 Markdown = ">=3.2"
 
 [[package]]
-category = "dev"
-description = "Python parsing module"
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "dev"
-description = "Mustache for Python"
 name = "pystache"
+version = "0.5.4"
+description = "Mustache for Python"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.5.4"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.1.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "6.1.2"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.8.2"
 toml = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa_mypy = ["mypy (0.780)"]
+checkqa_mypy = ["mypy (==0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest support for asyncio."
 name = "pytest-asyncio"
+version = "0.14.0"
+description = "Pytest support for asyncio."
+category = "dev"
 optional = false
 python-versions = ">= 3.5"
-version = "0.14.0"
 
 [package.dependencies]
 pytest = ">=5.4.0"
@@ -537,24 +507,24 @@ pytest = ">=5.4.0"
 testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
-category = "dev"
-description = "run tests in isolated forked subprocesses"
 name = "pytest-forked"
+version = "1.3.0"
+description = "run tests in isolated forked subprocesses"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "1.3.0"
 
 [package.dependencies]
 py = "*"
 pytest = ">=3.10"
 
 [[package]]
-category = "dev"
-description = "pytest plugin for writing tests for mypy plugins"
 name = "pytest-mypy-plugins"
+version = "1.6.1"
+description = "pytest plugin for writing tests for mypy plugins"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "1.6.1"
 
 [package.dependencies]
 decorator = "*"
@@ -564,12 +534,12 @@ pytest = ">=6.0.0"
 pyyaml = "*"
 
 [[package]]
-category = "dev"
-description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
 name = "pytest-xdist"
+version = "2.1.0"
+description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "2.1.0"
 
 [package.dependencies]
 execnet = ">=1.1"
@@ -581,118 +551,115 @@ psutil = ["psutil (>=3.0)"]
 testing = ["filelock"]
 
 [[package]]
-category = "dev"
-description = "Load Python objects documentation."
 name = "pytkdocs"
+version = "0.9.0"
+description = "Load Python objects documentation."
+category = "dev"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.9.0"
 
 [package.extras]
 tests = ["coverage (>=5.2.1,<6.0.0)", "invoke (>=1.4.1,<2.0.0)", "marshmallow (>=3.5.2,<4.0.0)", "mypy (>=0.782,<0.783)", "pydantic (>=1.5.1,<2.0.0)", "pytest (>=6.0.1,<7.0.0)", "pytest-cov (>=2.10.1,<3.0.0)", "pytest-randomly (>=3.4.1,<4.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=2.1.0,<3.0.0)"]
 
 [[package]]
-category = "dev"
-description = "YAML parser and emitter for Python"
 name = "pyyaml"
+version = "5.3.1"
+description = "YAML parser and emitter for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "5.3.1"
 
 [[package]]
-category = "dev"
-description = "Alternative regular expression module, to replace re."
 name = "regex"
+version = "2020.11.13"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2020.11.13"
 
 [[package]]
-category = "dev"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "dev"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
 name = "snowballstemmer"
+version = "2.0.0"
+description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2.0.0"
 
 [[package]]
-category = "dev"
-description = "A modern CSS selector implementation for Beautiful Soup."
-marker = "python_version >= \"3.0\""
 name = "soupsieve"
+version = "2.0.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "2.0.1"
 
 [[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.10.2"
 
 [[package]]
-category = "dev"
-description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 name = "tornado"
+version = "6.1"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+category = "dev"
 optional = false
 python-versions = ">= 3.5"
-version = "6.1"
 
 [[package]]
-category = "dev"
-description = "Fast, Extensible Progress Meter"
-marker = "python_version > \"2.7\""
 name = "tqdm"
+version = "4.54.0"
+description = "Fast, Extensible Progress Meter"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "4.54.0"
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown", "wheel"]
 
 [[package]]
-category = "dev"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
 name = "typed-ast"
-optional = false
-python-versions = "*"
 version = "1.4.1"
-
-[[package]]
+description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4.3"
 
 [[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "dev"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "5349aa0d10450f120d0eac9a74d79eac97c4f038196e9775db8e6305b7f8b9fd"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "^3.7"
+content-hash = "5349aa0d10450f120d0eac9a74d79eac97c4f038196e9775db8e6305b7f8b9fd"
 
 [metadata.files]
 apipkg = [

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -27,8 +27,8 @@ def test_register_spy(registry: Registry) -> None:
 def test_register_call(registry: Registry) -> None:
     """It should register a spy call."""
     spy = create_spy(handle_call=noop)
-    call_1 = SpyCall(spy_id=id(spy), args=(1,), kwargs={})
-    call_2 = SpyCall(spy_id=id(spy), args=(2,), kwargs={})
+    call_1 = SpyCall(spy_id=id(spy), spy_name="spy", args=(1,), kwargs={})
+    call_2 = SpyCall(spy_id=id(spy), spy_name="spy", args=(2,), kwargs={})
 
     registry.register_spy(spy)
     registry.register_call(call_1)
@@ -40,8 +40,8 @@ def test_register_call(registry: Registry) -> None:
 def test_pop_last_call(registry: Registry) -> None:
     """It should be able to pop the last spy call."""
     spy = create_spy(handle_call=noop)
-    call_1 = SpyCall(spy_id=id(spy), args=(1,), kwargs={})
-    call_2 = SpyCall(spy_id=id(spy), args=(2,), kwargs={})
+    call_1 = SpyCall(spy_id=id(spy), spy_name="spy", args=(1,), kwargs={})
+    call_2 = SpyCall(spy_id=id(spy), spy_name="spy", args=(2,), kwargs={})
 
     registry.register_spy(spy)
     registry.register_call(call_1)
@@ -55,8 +55,8 @@ def test_register_stub(registry: Registry) -> None:
     """It should register a stub."""
     spy = create_spy(handle_call=noop)
     spy_id = registry.register_spy(spy)
-    call_1 = SpyCall(spy_id=id(spy), args=(1,), kwargs={})
-    call_2 = SpyCall(spy_id=id(spy), args=(2,), kwargs={})
+    call_1 = SpyCall(spy_id=id(spy), spy_name="spy", args=(1,), kwargs={})
+    call_2 = SpyCall(spy_id=id(spy), spy_name="spy", args=(2,), kwargs={})
 
     stub_1 = Stub[Any](call_1)
     stub_2 = Stub[Any](call_2)
@@ -72,7 +72,7 @@ def test_register_stub(registry: Registry) -> None:
 def test_registered_calls_clean_up_automatically(registry: Registry) -> None:
     """It should clean up when the spy goes out of scope."""
     spy = create_spy(handle_call=noop)
-    call_1 = SpyCall(spy_id=id(spy), args=(1,), kwargs={})
+    call_1 = SpyCall(spy_id=id(spy), spy_name="spy", args=(1,), kwargs={})
     stub_1 = Stub[Any](call_1)
 
     spy_id = registry.register_spy(spy)

--- a/tests/test_spy.py
+++ b/tests/test_spy.py
@@ -26,9 +26,16 @@ def test_create_spy() -> None:
     spy(7, eight=8, nine=9)
 
     assert calls == [
-        SpyCall(spy_id=id(spy), args=(1, 2, 3), kwargs={}),
-        SpyCall(spy_id=id(spy), args=(), kwargs={"four": 4, "five": 5, "six": 6}),
-        SpyCall(spy_id=id(spy), args=(7,), kwargs={"eight": 8, "nine": 9}),
+        SpyCall(spy_id=id(spy), spy_name="spy", args=(1, 2, 3), kwargs={}),
+        SpyCall(
+            spy_id=id(spy),
+            spy_name="spy",
+            args=(),
+            kwargs={"four": 4, "five": 5, "six": 6},
+        ),
+        SpyCall(
+            spy_id=id(spy), spy_name="spy", args=(7,), kwargs={"eight": 8, "nine": 9}
+        ),
     ]
 
 
@@ -43,9 +50,19 @@ def test_create_spy_from_spec_function() -> None:
     spy(7, eight=8, nine=9)
 
     assert calls == [
-        SpyCall(spy_id=id(spy), args=(1, 2, 3), kwargs={}),
-        SpyCall(spy_id=id(spy), args=(), kwargs={"four": 4, "five": 5, "six": 6}),
-        SpyCall(spy_id=id(spy), args=(7,), kwargs={"eight": 8, "nine": 9}),
+        SpyCall(spy_id=id(spy), spy_name="some_func", args=(1, 2, 3), kwargs={}),
+        SpyCall(
+            spy_id=id(spy),
+            spy_name="some_func",
+            args=(),
+            kwargs={"four": 4, "five": 5, "six": 6},
+        ),
+        SpyCall(
+            spy_id=id(spy),
+            spy_name="some_func",
+            args=(7,),
+            kwargs={"eight": 8, "nine": 9},
+        ),
     ]
 
 
@@ -62,9 +79,19 @@ async def test_create_spy_from_async_spec_function() -> None:
     await spy(7, eight=8, nine=9)
 
     assert calls == [
-        SpyCall(spy_id=id(spy), args=(1, 2, 3), kwargs={}),
-        SpyCall(spy_id=id(spy), args=(), kwargs={"four": 4, "five": 5, "six": 6}),
-        SpyCall(spy_id=id(spy), args=(7,), kwargs={"eight": 8, "nine": 9}),
+        SpyCall(spy_id=id(spy), spy_name="some_async_func", args=(1, 2, 3), kwargs={}),
+        SpyCall(
+            spy_id=id(spy),
+            spy_name="some_async_func",
+            args=(),
+            kwargs={"four": 4, "five": 5, "six": 6},
+        ),
+        SpyCall(
+            spy_id=id(spy),
+            spy_name="some_async_func",
+            args=(7,),
+            kwargs={"eight": 8, "nine": 9},
+        ),
     ]
 
 
@@ -79,9 +106,21 @@ def test_create_spy_from_spec_class() -> None:
     spy.do_the_thing(7, eight=8, nine=9)
 
     assert calls == [
-        SpyCall(spy_id=id(spy.foo), args=(1, 2, 3), kwargs={}),
-        SpyCall(spy_id=id(spy.bar), args=(), kwargs={"four": 4, "five": 5, "six": 6}),
-        SpyCall(spy_id=id(spy.do_the_thing), args=(7,), kwargs={"eight": 8, "nine": 9}),
+        SpyCall(
+            spy_id=id(spy.foo), spy_name="SomeClass.foo", args=(1, 2, 3), kwargs={}
+        ),
+        SpyCall(
+            spy_id=id(spy.bar),
+            spy_name="SomeClass.bar",
+            args=(),
+            kwargs={"four": 4, "five": 5, "six": 6},
+        ),
+        SpyCall(
+            spy_id=id(spy.do_the_thing),
+            spy_name="SomeClass.do_the_thing",
+            args=(7,),
+            kwargs={"eight": 8, "nine": 9},
+        ),
     ]
 
 
@@ -96,9 +135,21 @@ async def test_create_spy_from_async_spec_class() -> None:
     await spy.do_the_thing(7, eight=8, nine=9)
 
     assert calls == [
-        SpyCall(spy_id=id(spy.foo), args=(1, 2, 3), kwargs={}),
-        SpyCall(spy_id=id(spy.bar), args=(), kwargs={"four": 4, "five": 5, "six": 6}),
-        SpyCall(spy_id=id(spy.do_the_thing), args=(7,), kwargs={"eight": 8, "nine": 9}),
+        SpyCall(
+            spy_id=id(spy.foo), spy_name="SomeAsyncClass.foo", args=(1, 2, 3), kwargs={}
+        ),
+        SpyCall(
+            spy_id=id(spy.bar),
+            spy_name="SomeAsyncClass.bar",
+            args=(),
+            kwargs={"four": 4, "five": 5, "six": 6},
+        ),
+        SpyCall(
+            spy_id=id(spy.do_the_thing),
+            spy_name="SomeAsyncClass.do_the_thing",
+            args=(7,),
+            kwargs={"eight": 8, "nine": 9},
+        ),
     ]
 
 
@@ -113,14 +164,21 @@ def test_create_nested_spy() -> None:
     spy.child.do_the_thing(7, eight=8, nine=9)
 
     assert calls == [
-        SpyCall(spy_id=id(spy.foo), args=(1, 2, 3), kwargs={}),
+        SpyCall(
+            spy_id=id(spy.foo),
+            spy_name="SomeNestedClass.foo",
+            args=(1, 2, 3),
+            kwargs={},
+        ),
         SpyCall(
             spy_id=id(spy.child.bar),
+            spy_name="SomeNestedClass.child.bar",
             args=(),
             kwargs={"four": 4, "five": 5, "six": 6},
         ),
         SpyCall(
             spy_id=id(spy.child.do_the_thing),
+            spy_name="SomeNestedClass.child.do_the_thing",
             args=(7,),
             kwargs={"eight": 8, "nine": 9},
         ),
@@ -148,11 +206,13 @@ async def test_create_nested_spy_using_property_type_hints() -> None:
     assert calls == [
         SpyCall(
             spy_id=id(spy._async_child.bar),
+            spy_name="_SomeClass._async_child.bar",
             args=(),
             kwargs={"four": 4, "five": 5, "six": 6},
         ),
         SpyCall(
             spy_id=id(spy._sync_child.do_the_thing),
+            spy_name="_SomeClass._sync_child.do_the_thing",
             args=(7,),
             kwargs={"eight": 8, "nine": 9},
         ),
@@ -175,11 +235,13 @@ async def test_create_nested_spy_using_class_type_hints() -> None:
     assert calls == [
         SpyCall(
             spy_id=id(spy._async_child.bar),
+            spy_name="_SomeClass._async_child.bar",
             args=(),
             kwargs={"four": 4, "five": 5, "six": 6},
         ),
         SpyCall(
             spy_id=id(spy._sync_child.do_the_thing),
+            spy_name="_SomeClass._sync_child.do_the_thing",
             args=(7,),
             kwargs={"eight": 8, "nine": 9},
         ),
@@ -204,3 +266,38 @@ async def test_spy_returns_handler_value() -> None:
         sync_spy(),
         await async_spy(),
     ] == [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize(
+    ("call", "expected"),
+    [
+        (
+            SpyCall(spy_id=42, spy_name="some.name", args=(), kwargs={}),
+            "some.name()",
+        ),
+        (
+            SpyCall(spy_id=42, spy_name="some.name", args=(1,), kwargs={}),
+            "some.name(1)",
+        ),
+        (
+            SpyCall(spy_id=42, spy_name="some.name", args=(1, "2"), kwargs={}),
+            "some.name(1, '2')",
+        ),
+        (
+            SpyCall(spy_id=42, spy_name="some.name", args=(), kwargs={"foo": "bar"}),
+            "some.name(foo='bar')",
+        ),
+        (
+            SpyCall(
+                spy_id=42,
+                spy_name="some.name",
+                args=(1, 2),
+                kwargs={"foo": "bar", "baz": False},
+            ),
+            "some.name(1, 2, foo='bar', baz=False)",
+        ),
+    ],
+)
+def test_spy_call_stringifies(call: SpyCall, expected: str) -> None:
+    """It should serialize SpyCalls to strings."""
+    assert str(call) == expected

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,6 +1,7 @@
 """Tests for the Decoy double creator."""
 import pytest
 
+from os import linesep
 from decoy import Decoy, matchers
 from .common import SomeClass, SomeNestedClass, some_func
 
@@ -19,10 +20,10 @@ def test_call_function_then_verify(decoy: Decoy) -> None:
         decoy.verify(stub("fizzbuzz"))
 
     assert str(error_info.value) == (
-        "Expected call:\n"
-        "\tsome_func('fizzbuzz')\n"
-        "Found 2 calls:\n"
-        "1.\tsome_func('hello')\n"
+        f"Expected call:{linesep}"
+        f"\tsome_func('fizzbuzz'){linesep}"
+        f"Found 2 calls:{linesep}"
+        f"1.\tsome_func('hello'){linesep}"
         "2.\tsome_func('goodbye')"
     )
 
@@ -46,10 +47,10 @@ def test_call_method_then_verify(decoy: Decoy) -> None:
         decoy.verify(stub.foo("fizzbuzz"))
 
     assert str(error_info.value) == (
-        "Expected call:\n"
-        "\tSomeClass.foo('fizzbuzz')\n"
-        "Found 2 calls:\n"
-        "1.\tSomeClass.foo('hello')\n"
+        f"Expected call:{linesep}"
+        f"\tSomeClass.foo('fizzbuzz'){linesep}"
+        f"Found 2 calls:{linesep}"
+        f"1.\tSomeClass.foo('hello'){linesep}"
         "2.\tSomeClass.foo('goodbye')"
     )
 
@@ -57,10 +58,10 @@ def test_call_method_then_verify(decoy: Decoy) -> None:
         decoy.verify(stub.bar(6, 7.0, "8"))
 
     assert str(error_info.value) == (
-        "Expected call:\n"
-        "\tSomeClass.bar(6, 7.0, '8')\n"
-        "Found 2 calls:\n"
-        "1.\tSomeClass.bar(0, 1.0, '2')\n"
+        f"Expected call:{linesep}"
+        f"\tSomeClass.bar(6, 7.0, '8'){linesep}"
+        f"Found 2 calls:{linesep}"
+        f"1.\tSomeClass.bar(0, 1.0, '2'){linesep}"
         "2.\tSomeClass.bar(3, 4.0, '5')"
     )
 
@@ -77,9 +78,9 @@ def test_verify_with_matcher(decoy: Decoy) -> None:
         decoy.verify(stub(matchers.StringMatching("^ell")))
 
     assert str(error_info.value) == (
-        "Expected call:\n"
-        "\tsome_func(<StringMatching '^ell'>)\n"
-        "Found 1 call:\n"
+        f"Expected call:{linesep}"
+        f"\tsome_func(<StringMatching '^ell'>){linesep}"
+        f"Found 1 call:{linesep}"
         "1.\tsome_func('hello')"
     )
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -15,8 +15,16 @@ def test_call_function_then_verify(decoy: Decoy) -> None:
     decoy.verify(stub("hello"))
     decoy.verify(stub("goodbye"))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError) as error_info:
         decoy.verify(stub("fizzbuzz"))
+
+    assert str(error_info.value) == (
+        "Expected call:\n"
+        "\tsome_func('fizzbuzz')\n"
+        "Found 2 calls:\n"
+        "1.\tsome_func('hello')\n"
+        "2.\tsome_func('goodbye')"
+    )
 
 
 def test_call_method_then_verify(decoy: Decoy) -> None:
@@ -34,11 +42,27 @@ def test_call_method_then_verify(decoy: Decoy) -> None:
     decoy.verify(stub.bar(0, 1.0, "2"))
     decoy.verify(stub.bar(3, 4.0, "5"))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError) as error_info:
         decoy.verify(stub.foo("fizzbuzz"))
 
-    with pytest.raises(AssertionError):
+    assert str(error_info.value) == (
+        "Expected call:\n"
+        "\tSomeClass.foo('fizzbuzz')\n"
+        "Found 2 calls:\n"
+        "1.\tSomeClass.foo('hello')\n"
+        "2.\tSomeClass.foo('goodbye')"
+    )
+
+    with pytest.raises(AssertionError) as error_info:
         decoy.verify(stub.bar(6, 7.0, "8"))
+
+    assert str(error_info.value) == (
+        "Expected call:\n"
+        "\tSomeClass.bar(6, 7.0, '8')\n"
+        "Found 2 calls:\n"
+        "1.\tSomeClass.bar(0, 1.0, '2')\n"
+        "2.\tSomeClass.bar(3, 4.0, '5')"
+    )
 
 
 def test_verify_with_matcher(decoy: Decoy) -> None:
@@ -49,8 +73,15 @@ def test_verify_with_matcher(decoy: Decoy) -> None:
 
     decoy.verify(stub(matchers.StringMatching("ell")))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError) as error_info:
         decoy.verify(stub(matchers.StringMatching("^ell")))
+
+    assert str(error_info.value) == (
+        "Expected call:\n"
+        "\tsome_func(<StringMatching '^ell'>)\n"
+        "Found 1 call:\n"
+        "1.\tsome_func('hello')"
+    )
 
 
 def test_call_nested_method_then_verify(decoy: Decoy) -> None:


### PR DESCRIPTION
Closes #4. See ticket for details. This PR adds assertion messages to failed `verify` calls:

```
E       AssertionError: Expected call:
E       	some_func('fizzbuzz')
E       Found 2 calls:
E       1.	some_func('hello')
E       2.	some_func('goodbye')
```