### PR TITLE
feat(when): warn if stub is called with args that do not match

### DIFF
--- a/decoy/registry.py
+++ b/decoy/registry.py
@@ -40,7 +40,7 @@ class Registry:
         """Get a spy's stub list by identifier.
 
         Arguments:
-            spy_id: The unique identifer of the Spy to look up.
+            spy_id: The unique identifier of the Spy to look up.
 
         Returns:
             The list of stubs matching the given Spy.
@@ -51,7 +51,7 @@ class Registry:
         """Get a spy's call list by identifier.
 
         Arguments:
-            spy_id: The unique identifer of the Spy to look up.
+            spy_id: The unique identifier of the Spy to look up.
 
         Returns:
             The list of calls matching the given Spy.
@@ -83,7 +83,7 @@ class Registry:
         """Register a stub for tracking.
 
         Arguments:
-            spy_id: The unique identifer of the Spy to look up.
+            spy_id: The unique identifier of the Spy to look up.
             stub: The stub to track.
         """
         stub_list = self.get_stubs_by_spy_id(spy_id)

--- a/decoy/warnings.py
+++ b/decoy/warnings.py
@@ -1,0 +1,30 @@
+"""Warnings produced by Decoy."""
+from os import linesep
+from typing import Any, Sequence
+
+from .spy import SpyCall
+from .stub import Stub
+
+
+class MissingStubWarning(UserWarning):
+    """A warning raised when a configured stub is called with different arguments."""
+
+    def __init__(self, call: SpyCall, stubs: Sequence[Stub[Any]]) -> None:
+        """Initialize the warning message with the actual and expected calls."""
+        stubs_len = len(stubs)
+        stubs_plural = stubs_len != 1
+        stubs_printout = linesep.join(
+            [f"{n + 1}.\t{str(stubs[n]._rehearsal)}" for n in range(stubs_len)]
+        )
+
+        message = linesep.join(
+            [
+                "Stub was called but no matching rehearsal found.",
+                f"Found {stubs_len} rehearsal{'s' if stubs_plural else ''}:",
+                stubs_printout,
+                "Actual call:",
+                f"\t{str(call)}",
+            ]
+        )
+
+        super().__init__(message)

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,3 +5,5 @@
 ::: decoy.stub.Stub
 
 ::: decoy.matchers
+
+::: decoy.warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,18 @@ from decoy import Decoy
 
 @pytest.fixture
 def decoy() -> Decoy:
-    """Get a new instance of the Decoy state container."""
+    """Get a new instance of the Decoy state container.
+
+    Warnings are disabled for more quiet tests.
+    """
+    return Decoy(warn_on_missing_stubs=False)
+
+
+@pytest.fixture
+def strict_decoy() -> Decoy:
+    """Get a new instance of the Decoy state container.
+
+    Warnings are left in the default enabled state. Use this fixture
+    to test warning behavior.
+    """
     return Decoy()

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,63 @@
+"""Tests for warning messages."""
+from os import linesep
+
+from decoy.spy import SpyCall
+from decoy.stub import Stub
+from decoy.warnings import MissingStubWarning
+
+
+def test_no_stubbing_found_warning() -> None:
+    """It should print a helpful error message if a call misses a stub."""
+    call = SpyCall(spy_id="123", spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
+    stub = Stub(
+        rehearsal=SpyCall(
+            spy_id="123",
+            spy_name="spy",
+            args=(3, 4),
+            kwargs={"baz": "qux"},
+        )
+    )
+
+    result = MissingStubWarning(call=call, stubs=[stub])
+
+    assert str(result) == (
+        f"Stub was called but no matching rehearsal found.{linesep}"
+        f"Found 1 rehearsal:{linesep}"
+        f"1.\tspy(3, 4, baz='qux'){linesep}"
+        f"Actual call:{linesep}"
+        "\tspy(1, 2, foo='bar')"
+    )
+
+
+def test_no_stubbing_found_warning_plural() -> None:
+    """It should print a helpful message if a call misses multiple stubs."""
+    call = SpyCall(spy_id="123", spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
+    stubs = [
+        Stub(
+            rehearsal=SpyCall(
+                spy_id="123",
+                spy_name="spy",
+                args=(3, 4),
+                kwargs={"baz": "qux"},
+            )
+        ),
+        Stub(
+            rehearsal=SpyCall(
+                spy_id="123",
+                spy_name="spy",
+                args=(5, 6),
+                kwargs={"fizz": "buzz"},
+            )
+        ),
+    ]
+
+    result = MissingStubWarning(call=call, stubs=stubs)
+
+    assert str(result) == (
+        f"Stub was called but no matching rehearsal found.{linesep}"
+        f"Found 2 rehearsals:{linesep}"
+        f"1.\tspy(3, 4, baz='qux'){linesep}"
+        f"2.\tspy(5, 6, fizz='buzz'){linesep}"
+        f"Actual call:{linesep}"
+        "\tspy(1, 2, foo='bar')"
+    )

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,5 +1,6 @@
 """Tests for warning messages."""
 from os import linesep
+from typing import Any, List
 
 from decoy.spy import SpyCall
 from decoy.stub import Stub
@@ -8,10 +9,10 @@ from decoy.warnings import MissingStubWarning
 
 def test_no_stubbing_found_warning() -> None:
     """It should print a helpful error message if a call misses a stub."""
-    call = SpyCall(spy_id="123", spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
-    stub = Stub(
+    call = SpyCall(spy_id=123, spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
+    stub: Stub[Any] = Stub(
         rehearsal=SpyCall(
-            spy_id="123",
+            spy_id=123,
             spy_name="spy",
             args=(3, 4),
             kwargs={"baz": "qux"},
@@ -31,11 +32,11 @@ def test_no_stubbing_found_warning() -> None:
 
 def test_no_stubbing_found_warning_plural() -> None:
     """It should print a helpful message if a call misses multiple stubs."""
-    call = SpyCall(spy_id="123", spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
-    stubs = [
+    call = SpyCall(spy_id=123, spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
+    stubs: List[Stub[Any]] = [
         Stub(
             rehearsal=SpyCall(
-                spy_id="123",
+                spy_id=123,
                 spy_name="spy",
                 args=(3, 4),
                 kwargs={"baz": "qux"},
@@ -43,7 +44,7 @@ def test_no_stubbing_found_warning_plural() -> None:
         ),
         Stub(
             rehearsal=SpyCall(
-                spy_id="123",
+                spy_id=123,
                 spy_name="spy",
                 args=(5, 6),
                 kwargs={"fizz": "buzz"},

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -1,7 +1,7 @@
 """Tests for the Decoy double creator."""
 import pytest
 
-from decoy import Decoy, matchers
+from decoy import Decoy, matchers, warnings
 from .common import some_func, SomeClass, SomeAsyncClass, SomeNestedClass
 
 
@@ -159,3 +159,23 @@ async def test_stub_nested_async_class_in_sync(decoy: Decoy) -> None:
     decoy.when(await stub._async_child.foo("hello")).then_return("world")
 
     assert await stub._async_child.foo("hello") == "world"
+
+
+def test_no_stubbing_found_warning(strict_decoy: Decoy) -> None:
+    """It should raise a warning if a stub is configured and then called incorrectly."""
+    stub = strict_decoy.create_decoy_func(spec=some_func)
+
+    strict_decoy.when(stub("hello")).then_return("world")
+
+    with pytest.warns(warnings.MissingStubWarning):
+        stub("h3110")
+
+
+@pytest.mark.filterwarnings("error::UserWarning")
+def test_no_stubbing_found_warnings_disabled(decoy: Decoy) -> None:
+    """It should not raise a warning if warn_on_missing_stub is disabled."""
+    stub = decoy.create_decoy_func(spec=some_func)
+
+    decoy.when(stub("hello")).then_return("world")
+
+    stub("h3110")


### PR DESCRIPTION
## Overview

This PR adds a warning (via the built-in [warnings](https://docs.python.org/3/library/warnings.html#module-warnings) module) if a stub is called with arguments that do not match a previous rehearsal.

Primarily, this serves as a quality of life upgrade to help test writers get to passing tests a little more quickly, and closes #14.

## Details

The decision to log a warning instead of asserting is intentional: it is my opinion that a stub should not in the business of providing assertions and failing the test. Warnings provide a happy middle path, where a test writer has a clear indication if they messed up their arguments somehow, but isn't forced to interact with a stub correctly to get the tests to pass as part of a TDD flow.

Warnings may be disabled at the `Decoy` container level using: `Decoy(warn_on_missing_stubs=False)`. The default behavior is to enable warnings, because that will be the most beneficial in normal usage. Because they are warnings (and nobody really uses this library yet 🙃), I'm going to call this "not a breaking change".