### PR TITLE
feat(when): warn if stub is called incorrectly

### DIFF
--- a/decoy/registry.py
+++ b/decoy/registry.py
@@ -40,7 +40,7 @@ class Registry:
         """Get a spy's stub list by identifier.
 
         Arguments:
-            spy_id: The unique identifer of the Spy to look up.
+            spy_id: The unique identifier of the Spy to look up.
 
         Returns:
             The list of stubs matching the given Spy.
@@ -51,7 +51,7 @@ class Registry:
         """Get a spy's call list by identifier.
 
         Arguments:
-            spy_id: The unique identifer of the Spy to look up.
+            spy_id: The unique identifier of the Spy to look up.
 
         Returns:
             The list of calls matching the given Spy.
@@ -83,7 +83,7 @@ class Registry:
         """Register a stub for tracking.
 
         Arguments:
-            spy_id: The unique identifer of the Spy to look up.
+            spy_id: The unique identifier of the Spy to look up.
             stub: The stub to track.
         """
         stub_list = self.get_stubs_by_spy_id(spy_id)

--- a/decoy/warnings.py
+++ b/decoy/warnings.py
@@ -1,0 +1,30 @@
+"""Warnings produced by Decoy."""
+from os import linesep
+from typing import Any, Sequence
+
+from .spy import SpyCall
+from .stub import Stub
+
+
+class MissingStubWarning(UserWarning):
+    """A warning raised when a configured stub is called with different arguments."""
+
+    def __init__(self, call: SpyCall, stubs: Sequence[Stub[Any]]) -> None:
+        """Initialize the warning message with the actual and expected calls."""
+        stubs_len = len(stubs)
+        stubs_plural = stubs_len != 1
+        stubs_printout = linesep.join(
+            [f"{n + 1}.\t{str(stubs[n]._rehearsal)}" for n in range(stubs_len)]
+        )
+
+        message = linesep.join(
+            [
+                "Stub was called but no matching rehearsal found.",
+                f"Found {stubs_len} rehearsal{'s' if stubs_plural else ''}:",
+                stubs_printout,
+                "Actual call:",
+                f"\t{str(call)}",
+            ]
+        )
+
+        super().__init__(message)

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,3 +5,5 @@
 ::: decoy.stub.Stub
 
 ::: decoy.matchers
+
+::: decoy.warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,18 @@ from decoy import Decoy
 
 @pytest.fixture
 def decoy() -> Decoy:
-    """Get a new instance of the Decoy state container."""
+    """Get a new instance of the Decoy state container.
+
+    Warnings are disabled for more quiet tests.
+    """
+    return Decoy(warn_on_missing_stubs=False)
+
+
+@pytest.fixture
+def strict_decoy() -> Decoy:
+    """Get a new instance of the Decoy state container.
+
+    Warnings are left in the default enabled state. Use this fixture
+    to test warning behavior.
+    """
     return Decoy()

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,64 @@
+"""Tests for warning messages."""
+from os import linesep
+from typing import Any, List
+
+from decoy.spy import SpyCall
+from decoy.stub import Stub
+from decoy.warnings import MissingStubWarning
+
+
+def test_no_stubbing_found_warning() -> None:
+    """It should print a helpful error message if a call misses a stub."""
+    call = SpyCall(spy_id=123, spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
+    stub: Stub[Any] = Stub(
+        rehearsal=SpyCall(
+            spy_id=123,
+            spy_name="spy",
+            args=(3, 4),
+            kwargs={"baz": "qux"},
+        )
+    )
+
+    result = MissingStubWarning(call=call, stubs=[stub])
+
+    assert str(result) == (
+        f"Stub was called but no matching rehearsal found.{linesep}"
+        f"Found 1 rehearsal:{linesep}"
+        f"1.\tspy(3, 4, baz='qux'){linesep}"
+        f"Actual call:{linesep}"
+        "\tspy(1, 2, foo='bar')"
+    )
+
+
+def test_no_stubbing_found_warning_plural() -> None:
+    """It should print a helpful message if a call misses multiple stubs."""
+    call = SpyCall(spy_id=123, spy_name="spy", args=(1, 2), kwargs={"foo": "bar"})
+    stubs: List[Stub[Any]] = [
+        Stub(
+            rehearsal=SpyCall(
+                spy_id=123,
+                spy_name="spy",
+                args=(3, 4),
+                kwargs={"baz": "qux"},
+            )
+        ),
+        Stub(
+            rehearsal=SpyCall(
+                spy_id=123,
+                spy_name="spy",
+                args=(5, 6),
+                kwargs={"fizz": "buzz"},
+            )
+        ),
+    ]
+
+    result = MissingStubWarning(call=call, stubs=stubs)
+
+    assert str(result) == (
+        f"Stub was called but no matching rehearsal found.{linesep}"
+        f"Found 2 rehearsals:{linesep}"
+        f"1.\tspy(3, 4, baz='qux'){linesep}"
+        f"2.\tspy(5, 6, fizz='buzz'){linesep}"
+        f"Actual call:{linesep}"
+        "\tspy(1, 2, foo='bar')"
+    )


### PR DESCRIPTION
## Overview

This PR is a second attempt at #15. The previous attempt had a bug where stub configuration rehearsals would incorrectly trigger the `MissingStubWarning`. That PR was reverted.

This PR corrects the bug that was present in the initial implementation. Closes #14 for real this time