### PR TITLE
fix(typing): ensure create_decoy typing accepts ABC as spec

### DIFF
--- a/decoy/__init__.py
+++ b/decoy/__init__.py
@@ -1,6 +1,6 @@
 """Decoy test double stubbing and verification library."""
 from os import linesep
-from typing import cast, Any, Optional, Sequence, Type
+from typing import cast, Any, Callable, Optional, Sequence
 from warnings import warn
 
 from .registry import Registry
@@ -56,7 +56,12 @@ class Decoy:
 
         return actual_method
 
-    def create_decoy(self, spec: Type[ClassT], *, is_async: bool = False) -> ClassT:
+    def create_decoy(
+        self,
+        spec: Callable[..., ClassT],
+        *,
+        is_async: bool = False,
+    ) -> ClassT:
         """Create a class decoy for `spec`.
 
         Arguments:

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -14,6 +14,21 @@
   out: |
       main:9: note: Revealed type is 'main.Dependency*'
 
+- case: class_decoy_mimics_abstract_class_type
+  main: |
+      from abc import ABC
+      from decoy import Decoy
+
+      class Dependency(ABC):
+          def do_thing(self, input: str) -> int:
+              ...
+
+      decoy = Decoy()
+      fake = decoy.create_decoy(spec=Dependency)
+      reveal_type(fake)
+  out: |
+      main:10: note: Revealed type is 'main.Dependency*'
+
 - case: function_decoy_mimics_type
   main: |
       from decoy import Decoy


### PR DESCRIPTION
This PR simplifies the typing of `create_decoy` to allow ABC's to be passed in as `spec` without complaint. See #13 for details and background