### PR TITLE
feat: add mock method for creating mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ def test_add_todo(decoy: Decoy) -> None:
 
 ### Create a mock
 
-Use `decoy.create_decoy` to create a mock based on some specification. From there, inject the mock into your test subject.
+Use `decoy.mock` to create a mock based on some specification. From there, inject the mock into your test subject.
 
 ```python
 def test_add_todo(decoy: Decoy) -> None:
-    todo_store = decoy.create_decoy(spec=TodoStore)
+    todo_store = decoy.mock(cls=TodoStore)
     subject = TodoAPI(store=todo_store)
     ...
 ```
@@ -101,7 +101,7 @@ Use `decoy.when` to configure your mock's behaviors. For example, you can set th
 ```python
 def test_add_todo(decoy: Decoy) -> None:
     """Adding a todo should create a TodoItem in the TodoStore."""
-    todo_store = decoy.create_decoy(spec=TodoStore)
+    todo_store = decoy.mock(cls=TodoStore)
     subject = TodoAPI(store=todo_store)
 
     decoy.when(
@@ -123,7 +123,7 @@ Use `decoy.verify` to assert that a mock was called in a certain way. This is be
 ```python
 def test_remove_todo(decoy: Decoy) -> None:
     """Removing a todo should remove the item from the TodoStore."""
-    todo_store = decoy.create_decoy(spec=TodoStore)
+    todo_store = decoy.mock(cls=TodoStore)
     subject = TodoAPI(store=todo_store)
 
     subject.remove("abc123")

--- a/decoy/__init__.py
+++ b/decoy/__init__.py
@@ -48,7 +48,7 @@ class Decoy:
                 only applies if you don't use `cls` nor `func`.
 
         Returns:
-            A spy, typecast as the object its imitating, if any.
+            A spy typecast as the object it's imitating, if any.
 
         Example:
             ```python

--- a/docs/usage/create.md
+++ b/docs/usage/create.md
@@ -5,25 +5,36 @@ Decoy can create two kinds of mocks:
 -   Mocks of a class instance
 -   Mocks of a function
 
+Mocks are created using the [decoy.Decoy.mock][] method.
+
 ## Mocking a class
 
-To create a mock class instance, use [decoy.Decoy.create_decoy][]. Decoy will inspect type annotations and method signatures to automatically configure methods as synchronous or asynchronous. Decoy mocks are automatically deep.
-
-To type checkers, the mock will appear to have the exact same type as the `spec` argument. The mock will also pass `isinstance` checks.
+To mock a class instance, pass the `cls` argument to `decoy.mock`. Decoy will inspect type annotations and method signatures to automatically configure methods as synchronous or asynchronous. Decoy mocks are automatically deep.
 
 ```python
 def test_my_thing(decoy: Decoy) -> None:
-    some_dependency = decoy.create_decoy(spec=SomeDependency)
+    some_dependency = decoy.mock(cls=SomeDependency)
 ```
+
+To type checkers, the mock will appear to have the exact same type as the `cls` argument. The mock will also pass `isinstance` checks.
 
 ## Mocking a function
 
-To create a mock function, use [decoy.Decoy.create_decoy_func][]. Decoy can inspect a `spec` function signature to automatically configure the function as synchronous or asynchronous. Otherwise, the `is_async` argument can force the mock to be asynchronous.
-
-To type checkers, the mock will appear to have the exact same type as the `spec` argument, if used.
+To mock a function, pass the `func` argument to `decoy.mock`. Decoy will inspect `func` to automatically configure the function as synchronous or asynchronous.
 
 ```python
 def test_my_thing(decoy: Decoy) -> None:
-    mock_function = decoy.create_decoy_func(spec=some_function)
-    free_async_function = decoy.create_decoy_func(is_async=True)
+    mock_function = decoy.mock(func=some_function)
+```
+
+To type checkers, the mock will appear to have the exact same type as the `func` argument. The function mock will pass `inspect.signature` checks.
+
+## Creating an anonymous mock
+
+If you use neither `cls` nor `func` when calling `decoy.mock`, you will get an anonymous mock. You can use the `is_async` argument to return an asynchronous mock.
+
+```python
+def test_my_thing(decoy: Decoy) -> None:
+    anon_function = decoy.mock()
+    async_anon_function = decoy.mock(is_async=True)
 ```

--- a/docs/usage/errors-and-warnings.md
+++ b/docs/usage/errors-and-warnings.md
@@ -9,7 +9,7 @@ Decoy's job as a mocking library is to provide you, the user, with useful design
 A [decoy.errors.VerifyError][] will be raised if a call to [decoy.Decoy.verify][] does not match the given rehearsal. This is a normal assertion, and means your code under test isn't behaving according to your tests specifications.
 
 ```python
-func = decoy.create_decoy_func()
+func = decoy.mock()
 
 func("hello")
 
@@ -69,8 +69,8 @@ class Subject:
         return result
 
 def test_subject(decoy: Decoy):
-    data_getter = decoy.create_decoy(spec=DataGetter)
-    data_handler = decoy.create_decoy(spec=DataHandler)
+    data_getter = decoy.mock(cls=DataGetter)
+    data_handler = decoy.mock(cls=DataHandler)
     subject = Subject(data_getter=data_getter, data_handler=data_handler)
 
     decoy.when(data_getter.get("data-id")).then_return(42)
@@ -133,8 +133,8 @@ This, however, requires a sizable mentality shift in terms of how you use mocks 
 
 ```python
 def test_subject(decoy: Decoy):
-    data_getter = decoy.create_decoy(spec=DataGetter)
-    data_handler = decoy.create_decoy(spec=DataHandler)
+    data_getter = decoy.mock(cls=DataGetter)
+    data_handler = decoy.mock(cls=DataHandler)
     subject = Subject(data_getter=data_getter, data_handler=data_handler)
 
     decoy.when(data_getter.get("data-id")).then_return(42)

--- a/docs/usage/matchers.md
+++ b/docs/usage/matchers.md
@@ -17,7 +17,7 @@ from .logger import Logger
 from .my_thing import MyThing
 
 def test_log_warning(decoy: Decoy):
-    logger = decoy.create_decoy(spec=Logger)
+    logger = decoy.mock(cls=Logger)
 
     subject = MyThing(logger=logger)
 
@@ -46,7 +46,7 @@ from .event_consumer import EventConsumer
 
 
 def test_event_listener(decoy: Decoy):
-    event_source = decoy.create_decoy(spec=EventSource)
+    event_source = decoy.mock(cls=EventSource)
     subject = EventConsumer(event_source=event_source)
     captor = matchers.Captor()
 

--- a/docs/usage/verify.md
+++ b/docs/usage/verify.md
@@ -22,7 +22,7 @@ The `verify` API uses the same "rehearsal" syntax as the [`when` API](./when).
 
 ```python
 def test_my_thing(decoy: Decoy) -> None:
-    database = decoy.create_decoy(spec=Database)
+    database = decoy.mock(cls=Database)
 
     subject = MyThing(database=database)
     subject.delete_model_by_id("some-id")
@@ -39,7 +39,7 @@ If your dependency uses async/await, simply add `await` to the rehearsal:
 ```python
 @pytest.mark.asyncio
 async def test_my_async_thing(decoy: Decoy) -> None:
-    database = decoy.create_decoy(spec=Database)
+    database = decoy.mock(cls=Database)
 
     subject = MyThing(database=database)
     await subject.delete_model_by_id("some-id")

--- a/docs/usage/when.md
+++ b/docs/usage/when.md
@@ -8,7 +8,7 @@ A stub is a mock that is pre-configured to return a result or raise an error if 
 
 ```python
 def test_my_thing(decoy: Decoy) -> None:
-    database = decoy.create_decoy(spec=Database)
+    database = decoy.mock(cls=Database)
     subject = MyThing(database=database)
 
     decoy.when(database.get("some-id")).then_return(Model(id="some-id"))
@@ -32,7 +32,7 @@ You can configure your stub to raise an error if called in a certain way:
 
 ```python
 def test_my_thing_when_database_raises(decoy: Decoy) -> None:
-    database = decoy.create_decoy(spec=Database)
+    database = decoy.mock(cls=Database)
     subject = MyThing(database=database)
 
     decoy.when(database.get("foo")).then_raise(KeyError(f"foo does not exist"))
@@ -48,7 +48,7 @@ If your dependency uses async/await, simply add `await` to the rehearsal:
 ```python
 @pytest.mark.asyncio
 async def test_my_async_thing(decoy: Decoy) -> None:
-    database = decoy.create_decoy(spec=Database)
+    database = decoy.mock(cls=Database)
     subject = MyThing(database=database)
 
     decoy.when(await database.get("some-id")).then_return(Model(id="some-id"))

--- a/docs/why.md
+++ b/docs/why.md
@@ -177,7 +177,7 @@ def decoy() -> Decoy:
 
 @pytest.fixture
 def mock_database(decoy: Decoy) -> Database:
-    return decoy.create_decoy(spec=Database)
+    return decoy.mock(cls=Database)
 
 @pytest.fixture
 def mock_book() -> Book:
@@ -265,7 +265,7 @@ def decoy() -> Decoy:
 
 @pytest.fixture
 def mock_logger(decoy: Decoy) -> Logger:
-    return decoy.create_decoy(spec=Logger)
+    return decoy.mock(cls=Logger)
 ```
 
 For verification of spies, Decoy doesn't do much except set out to add typechecking.

--- a/tests/test_call_handler.py
+++ b/tests/test_call_handler.py
@@ -11,13 +11,13 @@ from decoy.call_handler import CallHandler
 @pytest.fixture
 def call_stack(decoy: Decoy) -> CallStack:
     """Get a mock instance of a CallStack."""
-    return decoy.create_decoy(spec=CallStack)
+    return decoy.mock(cls=CallStack)
 
 
 @pytest.fixture
 def stub_store(decoy: Decoy) -> StubStore:
     """Get a mock instance of a StubStore."""
-    return decoy.create_decoy(spec=StubStore)
+    return decoy.mock(cls=StubStore)
 
 
 @pytest.fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,37 +17,37 @@ from .common import SomeClass, noop
 @pytest.fixture
 def create_spy(decoy: Decoy) -> SpyFactory:
     """Get a mock instance of a create_spy factory function."""
-    return decoy.create_decoy_func(spec=default_create_spy)
+    return decoy.mock(func=default_create_spy)
 
 
 @pytest.fixture
 def call_handler(decoy: Decoy) -> CallHandler:
     """Get a mock instance of a create_spy factory function."""
-    return decoy.create_decoy(spec=CallHandler)
+    return decoy.mock(cls=CallHandler)
 
 
 @pytest.fixture
 def call_stack(decoy: Decoy) -> CallStack:
     """Get a mock instance of a CallStack."""
-    return decoy.create_decoy(spec=CallStack)
+    return decoy.mock(cls=CallStack)
 
 
 @pytest.fixture
 def stub_store(decoy: Decoy) -> StubStore:
     """Get a mock instance of a StubStore."""
-    return decoy.create_decoy(spec=StubStore)
+    return decoy.mock(cls=StubStore)
 
 
 @pytest.fixture
 def verifier(decoy: Decoy) -> Verifier:
     """Get a mock instance of a Verifier."""
-    return decoy.create_decoy(spec=Verifier)
+    return decoy.mock(cls=Verifier)
 
 
 @pytest.fixture
 def warning_checker(decoy: Decoy) -> WarningChecker:
     """Get a mock instance of a Verifier."""
-    return decoy.create_decoy(spec=WarningChecker)
+    return decoy.mock(cls=WarningChecker)
 
 
 @pytest.fixture

--- a/tests/test_decoy.py
+++ b/tests/test_decoy.py
@@ -1,29 +1,53 @@
 """Smoke and integration tests for main Decoy interface."""
 import pytest
 from decoy import Decoy
-from decoy.spy import Spy
+from decoy.spy import Spy, AsyncSpy
 
 from .common import SomeClass, SomeAsyncClass, some_func
 
 
 def test_decoy_creates_spy(decoy: Decoy) -> None:
     """It should be able to create a Spy from a class."""
+    subject = decoy.mock(cls=SomeClass)
+
+    assert isinstance(subject, SomeClass)
+    assert isinstance(subject, Spy)
+
+    # test deprecated create_decoy method
     subject = decoy.create_decoy(spec=SomeClass)
 
     assert isinstance(subject, SomeClass)
+    assert isinstance(subject, Spy)
 
 
 def test_decoy_creates_func_spy(decoy: Decoy) -> None:
     """It should be able to create a Spy from a class."""
+    subject = decoy.mock(func=some_func)
+
+    assert isinstance(subject, Spy)
+
+    # test deprecated create_decoy_func method
     subject = decoy.create_decoy_func(spec=some_func)
 
     assert isinstance(subject, Spy)
 
 
+def test_decoy_creates_async_func_spy(decoy: Decoy) -> None:
+    """It should be able to create a Spy from a class."""
+    subject = decoy.mock(is_async=True)
+
+    assert isinstance(subject, AsyncSpy)
+
+    # test deprecated create_decoy_func method
+    subject = decoy.create_decoy_func(is_async=True)
+
+    assert isinstance(subject, AsyncSpy)
+
+
 @pytest.mark.filterwarnings("ignore::decoy.warnings.MiscalledStubWarning")
 def test_when_smoke_test(decoy: Decoy) -> None:
     """It should be able to configure a stub with a rehearsal."""
-    subject = decoy.create_decoy_func(spec=some_func)
+    subject = decoy.mock(func=some_func)
 
     decoy.when(subject("hello")).then_return("hello world")
 
@@ -36,7 +60,7 @@ def test_when_smoke_test(decoy: Decoy) -> None:
 
 def test_verify_smoke_test(decoy: Decoy) -> None:
     """It should be able to configure a verification with a rehearsal."""
-    subject = decoy.create_decoy_func(spec=some_func)
+    subject = decoy.mock(func=some_func)
 
     subject("hello")
 
@@ -49,7 +73,7 @@ def test_verify_smoke_test(decoy: Decoy) -> None:
 @pytest.mark.asyncio
 async def test_when_async_smoke_test(decoy: Decoy) -> None:
     """It should be able to stub an async method."""
-    subject = decoy.create_decoy(spec=SomeAsyncClass)
+    subject = decoy.mock(cls=SomeAsyncClass)
 
     decoy.when(await subject.foo("hello")).then_return("world")
     decoy.when(await subject.bar(0, 1.0, "2")).then_raise(ValueError("oh no"))
@@ -63,7 +87,7 @@ async def test_when_async_smoke_test(decoy: Decoy) -> None:
 @pytest.mark.asyncio
 async def test_verify_async_smoke_test(decoy: Decoy) -> None:
     """It should be able to configure a verification with an async rehearsal."""
-    subject = decoy.create_decoy(spec=SomeAsyncClass)
+    subject = decoy.mock(cls=SomeAsyncClass)
 
     await subject.foo("hello")
 
@@ -75,7 +99,7 @@ async def test_verify_async_smoke_test(decoy: Decoy) -> None:
 
 def test_reset_smoke_test(decoy: Decoy) -> None:
     """It should be able to reset its state."""
-    subject = decoy.create_decoy(spec=SomeClass)
+    subject = decoy.mock(cls=SomeClass)
 
     subject.foo("hello")
     decoy.reset()

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -1,6 +1,48 @@
 # typing tests
 
-- case: class_decoy_mimics_type
+- case: mock_cls_mimics_type
+  main: |
+      from decoy import Decoy
+
+      class Dependency():
+          def do_thing(self, input: str) -> int:
+              return 42
+
+      decoy = Decoy()
+      fake = decoy.mock(cls=Dependency)
+      reveal_type(fake)
+  out: |
+      main:9: note: Revealed type is "main.Dependency*"
+
+- case: mock_cls_mimics_abstract_class_type
+  main: |
+      from abc import ABC
+      from decoy import Decoy
+
+      class Dependency(ABC):
+          def do_thing(self, input: str) -> int:
+              ...
+
+      decoy = Decoy()
+      fake = decoy.mock(cls=Dependency)
+      reveal_type(fake)
+  out: |
+      main:10: note: Revealed type is "main.Dependency*"
+
+- case: mock_func_mimics_type
+  main: |
+      from decoy import Decoy
+
+      def do_thing(input: str) -> int:
+          return 42
+
+      decoy = Decoy()
+      fake = decoy.mock(func=do_thing)
+      reveal_type(fake)
+  out: |
+      main:8: note: Revealed type is "def (input: builtins.str) -> builtins.int"
+
+- case: deprecated_create_decoy_mimics_type
   main: |
       from decoy import Decoy
 
@@ -14,7 +56,7 @@
   out: |
       main:9: note: Revealed type is "main.Dependency*"
 
-- case: class_decoy_mimics_abstract_class_type
+- case: deprecated_create_decoy_mimics_abstract_class_type
   main: |
       from abc import ABC
       from decoy import Decoy
@@ -29,7 +71,7 @@
   out: |
       main:10: note: Revealed type is "main.Dependency*"
 
-- case: function_decoy_mimics_type
+- case: deprecated_create_decoy_func_mimics_type
   main: |
       from decoy import Decoy
 
@@ -51,7 +93,7 @@
               return 42
 
       decoy = Decoy()
-      fake = decoy.create_decoy(spec=Dependency)
+      fake = decoy.mock(cls=Dependency)
 
       decoy.when(fake.do_thing("hello")).then_return(42)
       decoy.when(fake.do_thing("goodbye")).then_return("wrong-type")
@@ -66,7 +108,7 @@
           return 42
 
       decoy = Decoy()
-      fake = decoy.create_decoy_func(spec=do_thing)
+      fake = decoy.mock(func=do_thing)
 
       decoy.when(fake("hello")).then_return(42)
       decoy.when(fake("goodbye")).then_return("wrong-type")


### PR DESCRIPTION
This PR deprecates the `create_decoy` and `create_decoy_func` methods in favor of a much more straightforward `mock` method.

```python
# before
# mock class instance
decoy.create_decoy(spec=SomeClass)
# mock function
decoy.create_decoy_func(spec=some_func)
# anonymous mock function
decoy.create_decoy_func()

# after
# mock class instance
decoy.mock(cls=SomeClass)
# mock function
decoy.mock(func=some_func)
# anonymous mock function
decoy.mock()
```

