### PR TITLE
fix(spy): match inspect.signature for staticmethods

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,12 +31,14 @@ theme:
         - media: "(prefers-color-scheme: light)"
           scheme: default
           primary: black
+          accent: indigo
           toggle:
               icon: material/weather-sunny
               name: Switch to dark mode
         - media: "(prefers-color-scheme: dark)"
           scheme: slate
           primary: amber
+          accent: yellow
           toggle:
               icon: material/weather-night
               name: Switch to light mode

--- a/tests/test_spy.py
+++ b/tests/test_spy.py
@@ -4,7 +4,7 @@ import inspect
 from typing import Any
 
 from decoy.spy_calls import SpyCall
-from decoy.spy import create_spy, AsyncSpy, SpyConfig
+from decoy.spy import create_spy, AsyncSpy, Spy, SpyConfig
 
 from .common import (
     noop,
@@ -347,6 +347,27 @@ def test_spy_matches_signature() -> None:
         ),
         return_annotation=Any,
     )
+
+
+def test_spy_matches_static_signature() -> None:
+    """It should pass `inspect.signature` checks on static methods."""
+
+    class _StaticClass:
+        @staticmethod
+        def foo(bar: int) -> float:
+            raise NotImplementedError()
+
+        @staticmethod
+        async def bar(baz: str) -> float:
+            raise NotImplementedError()
+
+    class_spy = create_spy(SpyConfig(spec=_StaticClass, handle_call=noop))
+    actual_instance = _StaticClass()
+
+    assert inspect.signature(class_spy.foo) == inspect.signature(actual_instance.foo)
+    assert inspect.signature(class_spy.bar) == inspect.signature(actual_instance.bar)
+    assert isinstance(class_spy.foo, Spy)
+    assert isinstance(class_spy.bar, AsyncSpy)
 
 
 def test_spy_repr() -> None:


### PR DESCRIPTION
## Overview

After [prompting from @SyntaxColoring](https://github.com/Opentrons/opentrons/pull/8161#discussion_r680034418), I wrote a test to see if Decoy correctly matched `inspect.signature` for `@staticmethod`'s of spec classes. Turns out it doesn't!

This PR fixes that bug.