### PR TITLE
refactor(spy): remove ununsed try/catch

### DIFF
--- a/decoy/spy.py
+++ b/decoy/spy.py
@@ -100,11 +100,7 @@ class BaseSpy:
         child_is_async = False
 
         if isclass(self._spec):
-            try:
-                child_hint = _get_type_hints(self._spec).get(name)
-            except Exception:
-                child_hint = None
-
+            child_hint = _get_type_hints(self._spec).get(name)
             child_spec = getattr_static(self._spec, name, child_hint)
 
         if isinstance(child_spec, property):

--- a/poetry.lock
+++ b/poetry.lock
@@ -100,6 +100,9 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
+[package.dependencies]
+toml = {version = "*", optional = true, markers = "extra == \"toml\""}
+
 [package.extras]
 toml = ["toml"]
 
@@ -678,7 +681,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "45cd11c3b500af463402a8c655184a548f65a6751f4ceed2623e3462d3ff93c7"
+content-hash = "3c37a52c3d3db38667259f801710f50406c1937615e7ccb6ace6846a0d3aa6ed"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pytest = "^6.1.2"
 pytest-asyncio = "^0.15.1"
 pytest-mypy-plugins = "^1.6.1"
 pytest-xdist = "^2.1.0"
-coverage = "^5.5"
+coverage = {extras = ["toml"], version = "^5.5"}
 
 [tool.poetry.plugins."pytest11"]
 "decoy" = "decoy.pytest_plugin"
@@ -50,6 +50,9 @@ files = ["decoy", "tests"]
 plugins = ["decoy/mypy/plugin.py"]
 strict = true
 show_error_codes = true
+
+[tool.coverage.report]
+exclude_lines = ["@overload"]
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]


### PR DESCRIPTION
Also ensure that `coverage.py` doesn't erroneously mark `typing.overload` method definitions as uncovered