### PR TITLE
fix(verify): improve verify traceback and error messsage

### DIFF
--- a/decoy/__init__.py
+++ b/decoy/__init__.py
@@ -5,6 +5,9 @@ from . import matchers, errors, warnings
 from .core import DecoyCore, StubCore
 from .types import ClassT, FuncT, ReturnT
 
+# ensure decoy does not pollute pytest tracebacks
+__tracebackhide__ = True
+
 
 class Decoy:
     """Decoy test double state container."""

--- a/decoy/core.py
+++ b/decoy/core.py
@@ -10,6 +10,9 @@ from .verifier import Verifier
 from .warning_checker import WarningChecker
 from .types import ReturnT
 
+# ensure decoy.core does not pollute Pytest tracebacks
+__tracebackhide__ = True
+
 
 class DecoyCore:
     """The DecoyCore class implements the main logic of Decoy."""

--- a/decoy/errors.py
+++ b/decoy/errors.py
@@ -60,7 +60,7 @@ class VerifyError(AssertionError):
             heading=heading,
             rehearsals=rehearsals,
             calls=calls,
-            include_calls=times is None,
+            include_calls=times is None or times == len(calls),
         )
 
         super().__init__(message)

--- a/decoy/stringify.py
+++ b/decoy/stringify.py
@@ -31,6 +31,11 @@ def count(count: int, noun: str) -> str:
     return f"{count} {noun}{'s' if count != 1 else ''}"
 
 
+def join_lines(*lines: str) -> str:
+    """Join a list of lines with newline characters."""
+    return os.linesep.join(lines).strip()
+
+
 def stringify_error_message(
     heading: str,
     rehearsals: Sequence[BaseSpyRehearsal],
@@ -38,14 +43,12 @@ def stringify_error_message(
     include_calls: bool = True,
 ) -> str:
     """Stringify an error message about a rehearsals to calls comparison."""
-    return os.linesep.join(
-        [
-            heading,
-            stringify_call_list(rehearsals),
-            (
-                f"Found {count(len(calls), 'call')}"
-                f"{'.' if len(calls) == 0 or not include_calls else ':'}"
-            ),
-            stringify_call_list(calls) if include_calls else "",
-        ]
-    ).strip()
+    return join_lines(
+        heading,
+        stringify_call_list(rehearsals),
+        (
+            f"Found {count(len(calls), 'call')}"
+            f"{'.' if len(calls) == 0 or not include_calls else ':'}"
+        ),
+        stringify_call_list(calls) if include_calls else "",
+    )

--- a/decoy/verifier.py
+++ b/decoy/verifier.py
@@ -4,6 +4,9 @@ from typing import Optional, Sequence
 from .spy_calls import SpyCall, VerifyRehearsal, match_call
 from .errors import VerifyError
 
+# ensure decoy.verifier does not pollute Pytest tracebacks
+__tracebackhide__ = True
+
 
 class Verifier:
     """An interface to verify that spies were called as expected."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -92,6 +92,23 @@ verify_error_specs = [
             ]
         ),
     ),
+    VerifyErrorSpec(
+        rehearsals=[
+            VerifyRehearsal(spy_id=101, spy_name="spy_101", args=(1, 2, 3), kwargs={}),
+        ],
+        calls=[
+            SpyCall(spy_id=101, spy_name="spy_101", args=(4, 5, 6), kwargs={}),
+        ],
+        times=1,
+        expected_message=os.linesep.join(
+            [
+                "Expected exactly 1 call:",
+                "1.\tspy_101(1, 2, 3)",
+                "Found 1 call:",
+                "1.\tspy_101(4, 5, 6)",
+            ]
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
- Ensure verify error message is helpful when actual call count matches the `times` argument
- Use `__tracebackhide__` to hide Decoy code from pytest traceback