### PR TITLE
feat(when): add ContextManager mocking support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ poetry run mkdocs serve
 
 The library and documentation will be deployed to PyPI and GitHub Pages, respectively, by CI. To trigger the deploy, cut a new version and push it to GitHub.
 
-Deploy adheres to [semantic versioning][], so care should be taken to bump accurately.
+Decoy adheres to [semantic versioning][], so care should be taken to bump accurately.
 
 ```bash
 # checkout the main branch and pull down latest changes

--- a/decoy/__init__.py
+++ b/decoy/__init__.py
@@ -10,12 +10,13 @@ __tracebackhide__ = True
 
 
 class Decoy:
-    """Decoy test double state container."""
+    """Decoy mock factory and state container."""
 
     def __init__(self) -> None:
-        """Initialize the state container for test doubles and stubs.
+        """Initialize a new mock factory.
 
-        You should initialize a new Decoy instance for every test. See the
+        You should create a new Decoy instance for every test. If you use
+        the `decoy` pytest fixture, this is done automatically. See the
         [setup guide](../#setup) for more details.
         """
         self._core = DecoyCore()
@@ -137,7 +138,7 @@ class Decoy:
         times: Optional[int] = None,
         ignore_extra_args: bool = False,
     ) -> None:
-        """Verify a decoy was called using one or more rehearsals.
+        """Verify a mock was called using one or more rehearsals.
 
         See [verification usage guide](../usage/verify/) for more details.
 
@@ -175,11 +176,11 @@ class Decoy:
         )
 
     def reset(self) -> None:
-        """Reset all decoy state.
+        """Reset all mock state.
 
         This method should be called after every test to ensure spies and stubs
-        don't leak between tests. The Decoy fixture provided by the pytest plugin
-        will do this automatically.
+        don't leak between tests. The `decoy` fixture provided by the pytest plugin
+        will call `reset` automatically.
 
         The `reset` method may also trigger warnings if Decoy detects any questionable
         mock usage. See [decoy.warnings][] for more details.

--- a/decoy/call_handler.py
+++ b/decoy/call_handler.py
@@ -2,8 +2,9 @@
 from typing import Any
 
 from .call_stack import CallStack
-from .stub_store import StubStore
+from .context_managers import ContextWrapper
 from .spy_calls import SpyCall
+from .stub_store import StubStore
 
 
 class CallHandler:
@@ -24,5 +25,8 @@ class CallHandler:
 
         if behavior.action:
             return behavior.action(*call.args, **call.kwargs)
+
+        if behavior.context_value:
+            return ContextWrapper(behavior.context_value)
 
         return behavior.return_value

--- a/decoy/context_managers.py
+++ b/decoy/context_managers.py
@@ -1,0 +1,46 @@
+"""Wrappers around contextlib types and fallbacks."""
+import contextlib
+from typing import Any, AsyncContextManager, ContextManager, Generic, TypeVar
+
+GeneratorContextManager = contextlib._GeneratorContextManager
+
+_EnterT = TypeVar("_EnterT")
+
+
+class ContextWrapper(
+    ContextManager[_EnterT],
+    AsyncContextManager[_EnterT],
+    Generic[_EnterT],
+):
+    """A simple, do-nothing ContextManager that wraps a given value.
+
+    Adapted from `contextlib.nullcontext` to ensure support across
+    all Python versions.
+    """
+
+    def __init__(self, enter_result: _EnterT) -> None:
+        self._enter_result = enter_result
+
+    def __enter__(self) -> _EnterT:
+        """Return the wrapped value."""
+        return self._enter_result
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> Any:
+        """No-op on exit."""
+        pass
+
+    async def __aenter__(self) -> _EnterT:
+        """Return the wrapped value."""
+        return self._enter_result
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> Any:
+        """No-op on exit."""
+        pass
+
+
+__all__ = [
+    "AsyncContextManager",
+    "GeneratorContextManager",
+    "ContextManager",
+    "ContextWrapper",
+]

--- a/decoy/core.py
+++ b/decoy/core.py
@@ -1,14 +1,15 @@
 """Decoy implementation logic."""
 from typing import Any, Callable, Optional
 
-from .spy import SpyConfig, SpyFactory, create_spy as default_create_spy
-from .spy_calls import WhenRehearsal
-from .call_stack import CallStack
-from .stub_store import StubStore, StubBehavior
 from .call_handler import CallHandler
+from .call_stack import CallStack
+from .spy import SpyConfig, SpyFactory
+from .spy import create_spy as default_create_spy
+from .spy_calls import WhenRehearsal
+from .stub_store import StubBehavior, StubStore
+from .types import ContextValueT, ReturnT
 from .verifier import Verifier
 from .warning_checker import WarningChecker
-from .types import ReturnT
 
 # ensure decoy.core does not pollute Pytest tracebacks
 __tracebackhide__ = True
@@ -114,4 +115,11 @@ class StubCore:
         self._stub_store.add(
             rehearsal=self._rehearsal,
             behavior=StubBehavior(action=action),
+        )
+
+    def then_enter_with(self, value: ContextValueT) -> None:
+        """Set the stub to return a ContextManager wrapped value."""
+        self._stub_store.add(
+            rehearsal=self._rehearsal,
+            behavior=StubBehavior(context_value=value),
         )

--- a/decoy/pytest_plugin.py
+++ b/decoy/pytest_plugin.py
@@ -4,12 +4,14 @@ The plugin will be registered with pytest when you install Decoy. It adds a
 fixture without modifying any other pytest behavior. Its usage is optional
 but highly recommended.
 """
-import pytest
 from typing import Iterable
+
+import pytest
+
 from decoy import Decoy
 
 
-@pytest.fixture
+@pytest.fixture()
 def decoy() -> Iterable[Decoy]:
     """Get a [decoy.Decoy][] container and tear it down after the test.
 

--- a/decoy/stub_store.py
+++ b/decoy/stub_store.py
@@ -8,6 +8,7 @@ class StubBehavior(NamedTuple):
     """A recorded stub behavior."""
 
     return_value: Optional[Any] = None
+    context_value: Optional[Any] = None
     error: Optional[Exception] = None
     action: Optional[Callable[..., Any]] = None
     once: bool = False

--- a/decoy/types.py
+++ b/decoy/types.py
@@ -9,3 +9,6 @@ ClassT = TypeVar("ClassT", bound=object)
 
 ReturnT = TypeVar("ReturnT")
 """The return type of a given call."""
+
+ContextValueT = TypeVar("ContextValueT")
+"""A context manager value returned by a stub."""

--- a/decoy/warning_checker.py
+++ b/decoy/warning_checker.py
@@ -2,7 +2,7 @@
 from typing import Dict, List, Sequence
 from warnings import warn
 
-from .spy_calls import BaseSpyCall, SpyCall, WhenRehearsal, VerifyRehearsal, match_call
+from .spy_calls import BaseSpyCall, SpyCall, VerifyRehearsal, WhenRehearsal, match_call
 from .warnings import MiscalledStubWarning, RedundantVerifyWarning
 
 
@@ -25,7 +25,7 @@ def _check_no_miscalled_stubs(all_calls: Sequence[BaseSpyCall]) -> None:
         spy_calls = all_calls_by_id.get(spy_id, [])
         all_calls_by_id[spy_id] = spy_calls + [call]
 
-    for spy_id, spy_calls in all_calls_by_id.items():
+    for spy_calls in all_calls_by_id.values():
         unmatched: List[SpyCall] = []
 
         for index, call in enumerate(spy_calls):

--- a/docs/advanced/context-managers.md
+++ b/docs/advanced/context-managers.md
@@ -1,6 +1,6 @@
-# Mocking Context Managers
+# Mocking context managers
 
-In Python, `with` statement [context managers][] provide an extremely useful interface to execute code inside a given "runtime context" that defines consistent and failsafe setup and teardown behavior. For example, Python's built-in file objects provide a context manager interface to ensure the underlying file resource is opened and closed cleanly, without the caller having to explicitly deal with it:
+In Python, `with` statement [context managers][] provide an extremely useful interface to execute code inside a given "runtime context." This context can define consistent, failsafe setup and teardown behavior. For example, Python's built-in file objects provide a context manager interface to ensure the underlying file resource is opened and closed cleanly, without the caller having to explicitly deal with it:
 
 ```python
 with open("hello-world.txt", "r") as f:
@@ -11,7 +11,7 @@ You can use Decoy to mock out your dependencies that should provide a context ma
 
 [context managers]: https://docs.python.org/3/reference/datamodel.html#context-managers
 
-## Generator-based Context Managers
+## Generator-based context managers
 
 Using the [contextlib][] module, you can [decorate a generator function][] or method to turn its yielded value into a context manager. This is a great API, and one that Decoy is well-suited to mock. To mock a generator function context manager, use [decoy.Stub.then_enter_with][].
 
@@ -76,7 +76,7 @@ class Core:
 [contextlib]: https://docs.python.org/3/library/contextlib.html
 [decorate a generator function]: https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager
 
-## General Context Managers
+## General context managers
 
 A context manager is simply an object with both `__enter__` and `__exit__` methods defined. Decoy mocks have both these methods defined, so they are compatible with the `with` statement. In the author's opinion, tests that mock `__enter__` and `__exit__` (or any double-underscore method) are harder to read and understand than tests that do not, so generator-based context managers should be prefered where applicable.
 
@@ -150,7 +150,7 @@ class Core:
             return loaded_config.read(name)
 ```
 
-## Async Context Managers
+## Asynchronous context managers
 
 Decoy is also compatible with mocking the async `__aenter__` and `__aexit__` methods of async context managers.
 

--- a/docs/advanced/context-managers.md
+++ b/docs/advanced/context-managers.md
@@ -1,0 +1,154 @@
+# Mocking Context Managers
+
+In Python, [`with` statement context managers][] provide an extremely useful interface to execute code inside a given "runtime context," that defines setup and teardown behavior that will run even if that code raises an error. Python's built-in file objects provide a context manager interface to ensure the underlying file resource is opened and closed cleanly, without the caller having to explicitly deal with it:
+
+```python
+with open("hello-world.txt", "r") as f:
+    contents = f.read()
+```
+
+You can use Decoy to mock out your dependencies that should provide a context manager interface.
+
+## Generator-based Context Managers
+
+Using the [contextlib][] module, you can decorate a generator function or method to turn its return value into a context manager. This is a great API, and one that Decoy is well-suited to mock. To mock a generator function context manager, **set your mock to return its value wrapped in a `contextmanager.nullcontext`**.
+
+```python
+import contextlib
+from my_module.core import Core
+from my_module.config import Config, ConfigLoader
+
+def test_loads_config(decoy: Decoy) -> None:
+    """It should load config from a ConfigLoader dependency.
+
+    In this example, we know we're going to read/write config
+    to/from an external source, like the filesystem. So we want to
+    implement this dependency as a context manager to ensure
+    resource cleanup.
+    """
+    config_loader = decoy.mock(ConfigLoader)
+    config = decoy.mock(Config)
+
+    subject = Core(config_loader=config_loader)
+
+    # use contextlib.nullcontext to return our mock
+    decoy.when(
+        config_loader.load()
+    ).then_return(contextlib.nullcontext(config))
+
+    decoy.when(
+        config.read("some_flag")
+    ).then_return(True)
+
+    result = subject.get_config("some_flag")
+
+    assert result is True
+```
+
+From this test, we could sketch out the following dependency APIs...
+
+```python
+# config.py
+import contextlib
+
+class Config:
+    def read(self, name: str) -> bool:
+        ...
+
+class ConfigLoader:
+    @contextlib.contextmanager
+    def load(self) -> Iterator[Config]:
+        ...
+```
+
+...along with our test subject's implementation to pass the test...
+
+```python
+# core.py
+from .config import Config, ConfigLoader
+
+class Core:
+    def __init__(self, config_laoder: ConfigLoader) -> None:
+        self._config_loader = config_loader
+
+    def get_config(self, name: str) -> bool:
+        with self._config_loader.load() as config:
+            return config.read(name)
+```
+
+## General Context Managers
+
+A context manager is simply an object with both `__enter__` and `__exit__` methods defined. Decoy mocks have both these methods defined, so they are compatible with the `with` statement. In the author's opinion, tests that mock `__enter__` and `__exit__` (or any double-underscore method) are more harder to read and understand than tests that do not, so generator-based context managers should be prefered where applicable.
+
+Using our earlier example, maybe you'd prefer to use a single `Config` dependency to both load the configuration resource and read values.
+
+```python
+import contextlib
+from my_module.core import Core
+from my_module.config import Config, ConfigLoader
+
+def test_loads_config(decoy: Decoy) -> None:
+    """It should load config from a Config dependency.
+
+    In this example, we know we're going to read/write config
+    to/from an external source, like the filesystem. So we want to
+    implement this dependency as a context manager to ensure
+    resource cleanup.
+    """
+    config = decoy.mock(Config)
+    subject = Core(config=config)
+
+    decoy.when(
+        config.__enter__()
+    ).then_return(config)
+
+    decoy.when(config.read("some_flag")).then_return(True)
+
+    result = subject.get_config("some_flag")
+
+    assert result is True
+
+    # since the Config is also the context manager, we have to
+    # verify the call to `__exit__` to ensure `with` was actually
+    # used instead of just calling `config.read`. This text smell
+    # is an indication that this API is too easy to misuse.
+    decoy.verify(config.__exit__(None, None, None))
+```
+
+From this test, our dependency APIs would be...
+
+```python
+# config.py
+from types import TracebackType
+from typing import Optional
+
+class Config:
+    def __enter__(self) -> Config:
+        ...
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[Exception],
+        traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
+        ...
+
+    def read(self, name: str) -> bool:
+        ...
+```
+
+...along with our test subject's implementation to pass the test...
+
+```python
+# core.py
+from .config import Config
+
+class Core:
+    def __init__(self, config: Config) -> None:
+        self._config = config
+
+    def get_config(self, name: str) -> bool:
+        with self._config as config:
+            return config.read(name)
+```

--- a/docs/usage/matchers.md
+++ b/docs/usage/matchers.md
@@ -1,8 +1,8 @@
-# Loosening assertions with matchers
+# Asserting with matchers
 
 Sometimes, when you're stubbing or verifying calls (or really when you're doing any sort of equality assertion in a test), you need to loosen a given assertion. For example, you may want to assert that a dependency is called with a string, but you don't care about the full contents of that string.
 
-Decoy includes [decoy.matchers][], which has a set of Python classes with `__eq__` methods defined that you can use in rehearsals and/or assertions in place of actual values
+Decoy includes the [decoy.matchers][] module, which is a set of Python classes with `__eq__` methods defined that you can use in rehearsals and/or assertions in place of actual values
 
 ## Basic usage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ nav:
           - usage/verify.md
           - usage/matchers.md
           - usage/errors-and-warnings.md
+    - Advanced Usage:
+          - advanced/context-managers.md
     - api.md
     - why.md
     - contributing.md

--- a/tests/test_decoy.py
+++ b/tests/test_decoy.py
@@ -1,5 +1,6 @@
 """Smoke and acceptance tests for main Decoy interface."""
 import contextlib
+import sys
 from typing import Any, AsyncIterator, ContextManager, Iterator, Optional
 
 import pytest
@@ -231,6 +232,11 @@ def test_generator_context_manager_mock(decoy: Decoy) -> None:
     assert result == 42
 
 
+# TODO(mc, 2021-12-14): remove skip when Python 3.6 support dropped in v2
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="contextlib.asynccontextmanager added in Python 3.7",
+)
 async def test_async_generator_context_manager_mock(decoy: Decoy) -> None:
     """It should be able to mock a generator-based context manager."""
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,8 +1,8 @@
 """Tests for Decoy's pytest plugin."""
-from pytest import Testdir
+import pytest
 
 
-def test_pytest_decoy_fixture(testdir: Testdir) -> None:
+def test_pytest_decoy_fixture(testdir: pytest.Testdir) -> None:
     """It should add a decoy test fixture."""
     # create a temporary pytest test file
     testdir.makepyfile(

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -115,6 +115,45 @@
   out: |
       main:10: error: Argument 1 to "then_return" of "Stub" has incompatible type "str"; expected "int"  [arg-type]
 
+- case: context_manager_stub_mimics_enter_type
+  main: |
+      import contextlib
+      from typing import Iterator
+      from decoy import Decoy
+
+      @contextlib.contextmanager
+      def do_thing(input: str) -> Iterator[int]:
+          yield 42
+
+      decoy = Decoy()
+      fake_cm = decoy.mock(func=do_thing)
+
+      decoy.when(fake_cm("hello")).then_enter_with(42)
+      decoy.when(fake_cm("goodbye")).then_enter_with("wrong-type")
+
+  out: |
+      main:13: error: Argument 1 to "then_enter_with" of "Stub" has incompatible type "str"; expected "int"  [arg-type]
+
+- case: context_manager_stub_rejects_wrong_spec
+  main: |
+      from decoy import Decoy
+
+      def do_thing(input: str) -> int:
+          return 42
+
+      decoy = Decoy()
+      fake_not_cm = decoy.mock(func=do_thing)
+      fake_any = decoy.mock()
+
+      decoy.when(fake_not_cm("hello")).then_enter_with(42)
+      decoy.when(fake_any("hello")).then_enter_with(42)
+
+  out: |
+      main:10: error: Invalid self argument "Stub[int]" to attribute function "then_enter_with" with type "Callable[[Stub[ContextManager[ContextValueT]], ContextValueT], None]"  [misc]
+      main:10: error: No overload variant of "then_enter_with" of "Stub" matches argument type "int"  [call-overload]
+      main:10: note: Possible overload variants:
+      main:10: note:     def then_enter_with(self, value: <nothing>) -> None
+
 - case: matchers_mimic_types
   main: |
       from decoy import matchers


### PR DESCRIPTION
Closes #58

- Added `Stub.then_enter_with` method for returning context manager wrapped values
    - Intended use case: mocking functions/methods decorated with `@contextlib.contextmanager`
- Added support for mocking `__enter__` and `__exit__` methods
    - Intended use case: mocking context manager classes directly
- Added advanced documentation for mocking context manager interfaces

Note: the addition of `then_enter_with` was initially unexpected, but solution proposed in #58 of simply using `contextlib.nullcontext` did not typecheck properly, and was a little difficult to read. I think the `then_enter_with` method, which typechecks well, is also more communicative of intent when reading tests