### PR TITLE
refactor: move spec inspection logic to Spec class

### DIFF
--- a/decoy/__init__.py
+++ b/decoy/__init__.py
@@ -1,4 +1,5 @@
 """Decoy stubbing and spying library."""
+from warnings import warn
 from typing import Any, Callable, Generic, Optional, Union, cast, overload
 
 from . import errors, matchers, warnings
@@ -15,15 +16,25 @@ __tracebackhide__ = True
 
 
 class Decoy:
-    """Decoy mock factory and state container."""
+    """Decoy mock factory and state container.
+
+    You should create a new Decoy instance before each test and call
+    [reset][decoy.Decoy.reset] after each test. If you use the
+    [`decoy` pytest fixture][decoy.pytest_plugin.decoy], this is done
+    automatically. See the [setup guide](../#setup) for more details.
+
+    Example:
+        ```python
+        decoy = Decoy()
+
+        # test your subject
+        ...
+
+        decoy.reset()
+        ```
+    """
 
     def __init__(self) -> None:
-        """Initialize a new mock factory.
-
-        You should create a new Decoy instance for every test. If you use
-        the [`decoy` pytest fixture][decoy.pytest_plugin.decoy], this is done
-        automatically. See the [setup guide](../#setup) for more details.
-        """
         self._core = DecoyCore()
 
     @overload
@@ -47,9 +58,9 @@ class Decoy:
         name: Optional[str] = None,
         is_async: bool = False,
     ) -> Any:
-        """Create a mock.
+        """Create a mock. See the [mock creation guide] for more details.
 
-        See the [mock creation guide](../usage/create/) for more details.
+        [mock creation guide]: ../usage/create/
 
         Arguments:
             cls: A class definition that the mock should imitate.
@@ -83,6 +94,11 @@ class Decoy:
         !!! warning "Deprecated since v1.6.0"
             Use [decoy.Decoy.mock][] with the `cls` parameter, instead.
         """
+        warn(
+            "decoy.create_decoy is deprecated; use decoy.mock(cls=...) instead.",
+            DeprecationWarning,
+        )
+
         spy = self._core.mock(spec=spec, is_async=is_async)
         return cast(ClassT, spy)
 
@@ -97,6 +113,11 @@ class Decoy:
         !!! warning "Deprecated since v1.6.0"
             Use [decoy.Decoy.mock][] with the `func` parameter, instead.
         """
+        warn(
+            "decoy.create_decoy_func is deprecated; use decoy.mock(func=...) instead.",
+            DeprecationWarning,
+        )
+
         spy = self._core.mock(spec=spec, is_async=is_async)
         return cast(FuncT, spy)
 

--- a/decoy/call_handler.py
+++ b/decoy/call_handler.py
@@ -1,7 +1,7 @@
 """Spy call handling."""
 from typing import Any
 
-from .call_stack import CallStack
+from .spy_log import SpyLog
 from .context_managers import ContextWrapper
 from .spy_calls import SpyCall
 from .stub_store import StubStore
@@ -10,23 +10,29 @@ from .stub_store import StubStore
 class CallHandler:
     """An interface to handle calls to spies."""
 
-    def __init__(self, call_stack: CallStack, stub_store: StubStore) -> None:
+    def __init__(self, spy_log: SpyLog, stub_store: StubStore) -> None:
         """Initialize the CallHandler with access to SpyCalls and Stubs."""
-        self._call_stack = call_stack
+        self._spy_log = spy_log
         self._stub_store = stub_store
 
     def handle(self, call: SpyCall) -> Any:
         """Handle a Spy's call, triggering stub behavior if necessary."""
         behavior = self._stub_store.get_by_call(call)
-        self._call_stack.push(call)
+        self._spy_log.push(call)
 
-        if behavior.error:
+        if behavior is None:
+            return None
+
+        elif behavior.error:
             raise behavior.error
 
-        if behavior.action:
-            return behavior.action(*call.args, **call.kwargs)
+        elif behavior.action:
+            return_value = behavior.action(*call.args, **call.kwargs)
 
-        if behavior.context_value:
-            return ContextWrapper(behavior.context_value)
+        elif behavior.context_value:
+            return_value = ContextWrapper(behavior.context_value)
 
-        return behavior.return_value
+        else:
+            return_value = behavior.return_value
+
+        return return_value

--- a/decoy/call_handler.py
+++ b/decoy/call_handler.py
@@ -23,16 +23,13 @@ class CallHandler:
         if behavior is None:
             return None
 
-        elif behavior.error:
+        if behavior.error:
             raise behavior.error
 
-        elif behavior.action:
-            return_value = behavior.action(*call.args, **call.kwargs)
+        if behavior.action:
+            return behavior.action(*call.args, **call.kwargs)
 
-        elif behavior.context_value:
-            return_value = ContextWrapper(behavior.context_value)
+        if behavior.context_value:
+            return ContextWrapper(behavior.context_value)
 
-        else:
-            return_value = behavior.return_value
-
-        return return_value
+        return behavior.return_value

--- a/decoy/core.py
+++ b/decoy/core.py
@@ -2,9 +2,10 @@
 from typing import Any, Callable, Optional
 
 from .call_handler import CallHandler
-from .call_stack import CallStack
-from .spy import SpyConfig, SpyFactory
-from .spy import create_spy as default_create_spy
+from .spy_log import SpyLog
+
+# from .spy import SpyConfig
+from .spy import SpyCreator
 from .spy_calls import WhenRehearsal
 from .stub_store import StubBehavior, StubStore
 from .types import ContextValueT, ReturnT
@@ -20,23 +21,23 @@ class DecoyCore:
 
     def __init__(
         self,
-        create_spy: Optional[SpyFactory] = None,
         verifier: Optional[Verifier] = None,
         warning_checker: Optional[WarningChecker] = None,
         stub_store: Optional[StubStore] = None,
-        call_stack: Optional[CallStack] = None,
+        spy_log: Optional[SpyLog] = None,
         call_handler: Optional[CallHandler] = None,
+        spy_creator: Optional[SpyCreator] = None,
     ) -> None:
         """Initialize the DecoyCore with its dependencies."""
-        self._create_spy = create_spy or default_create_spy
         self._verifier = verifier or Verifier()
         self._warning_checker = warning_checker or WarningChecker()
         self._stub_store = stub_store or StubStore()
-        self._call_stack = call_stack or CallStack()
+        self._spy_log = spy_log or SpyLog()
         self._call_hander = call_handler or CallHandler(
-            call_stack=self._call_stack,
+            spy_log=self._spy_log,
             stub_store=self._stub_store,
         )
+        self._spy_creator = spy_creator or SpyCreator(call_handler=self._call_hander)
 
     def mock(
         self,
@@ -46,17 +47,11 @@ class DecoyCore:
         is_async: bool = False,
     ) -> Any:
         """Create and register a new spy."""
-        config = SpyConfig(
-            spec=spec,
-            name=name,
-            is_async=is_async,
-            handle_call=self._call_hander.handle,
-        )
-        return self._create_spy(config)
+        return self._spy_creator.create(spec=spec, name=name, is_async=is_async)
 
     def when(self, _rehearsal: ReturnT, *, ignore_extra_args: bool) -> "StubCore":
         """Create a new stub from the last spy rehearsal."""
-        rehearsal = self._call_stack.consume_when_rehearsal(
+        rehearsal = self._spy_log.consume_when_rehearsal(
             ignore_extra_args=ignore_extra_args
         )
         return StubCore(rehearsal=rehearsal, stub_store=self._stub_store)
@@ -68,19 +63,19 @@ class DecoyCore:
         ignore_extra_args: bool,
     ) -> None:
         """Verify that a Spy or Spies were called."""
-        rehearsals = self._call_stack.consume_verify_rehearsals(
+        rehearsals = self._spy_log.consume_verify_rehearsals(
             count=len(_rehearsals),
             ignore_extra_args=ignore_extra_args,
         )
-        calls = self._call_stack.get_by_rehearsals(rehearsals)
+        calls = self._spy_log.get_by_rehearsals(rehearsals)
 
         self._verifier.verify(rehearsals=rehearsals, calls=calls, times=times)
 
     def reset(self) -> None:
         """Reset and remove all stored spies and stubs."""
-        calls = self._call_stack.get_all()
+        calls = self._spy_log.get_all()
         self._warning_checker.check(calls)
-        self._call_stack.clear()
+        self._spy_log.clear()
         self._stub_store.clear()
 
 

--- a/decoy/core.py
+++ b/decoy/core.py
@@ -2,11 +2,9 @@
 from typing import Any, Callable, Optional
 
 from .call_handler import CallHandler
-from .spy_log import SpyLog
-
-# from .spy import SpyConfig
 from .spy import SpyCreator
 from .spy_calls import WhenRehearsal
+from .spy_log import SpyLog
 from .stub_store import StubBehavior, StubStore
 from .types import ContextValueT, ReturnT
 from .verifier import Verifier

--- a/decoy/spec.py
+++ b/decoy/spec.py
@@ -88,10 +88,10 @@ class Spec:
         if isinstance(source, functools.partial):
             source = source.func
 
+        # check if spec source is a class with a __call__ method
         elif inspect.isclass(source):
             call_method = inspect.getattr_static(source, "__call__", None)
-
-            if call_method is not None:
+            if inspect.isfunction(call_method):
                 source = call_method
 
         return inspect.iscoroutinefunction(source)

--- a/decoy/spec.py
+++ b/decoy/spec.py
@@ -1,0 +1,155 @@
+"""Mock specification."""
+import inspect
+import functools
+import warnings
+from typing import Any, Dict, NamedTuple, Optional, Tuple, Type, Union, get_type_hints
+
+from .warnings import IncorrectCallWarning
+
+
+class BoundArgs(NamedTuple):
+    """Arguments bound to a spec."""
+
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
+
+
+class Spec:
+    """Interface defining a Spy's specification.
+
+    Arguments:
+        source: The source object for the specification.
+        name: The spec's name. If left unspecified, will be derived from
+            `source`, if possible. Will fallback to a default value.
+        module_name: The spec's module name. If left unspecified or `True`,
+            will be derived from `source`, if possible. If explicitly set to `None`
+            or `False` or it is unable to be derived, a module name will not be used.
+
+    """
+
+    _DEFAULT_SPY_NAME = "spy"
+
+    def __init__(
+        self,
+        source: Optional[Any],
+        name: Optional[str],
+        module_name: Union[str, bool, None] = True,
+    ) -> None:
+        self._source = source
+
+        if name is not None:
+            self._name = name
+        elif source is not None:
+            self._name = getattr(source, "__name__", self._DEFAULT_SPY_NAME)
+        else:
+            self._name = self._DEFAULT_SPY_NAME
+
+        if isinstance(module_name, str):
+            self._module_name: Optional[str] = module_name
+        elif module_name is True and source is not None:
+            self._module_name = getattr(source, "__module__", None)
+        else:
+            self._module_name = None
+
+    def get_name(self) -> str:
+        """Get the Spec's human readable name.
+
+        Name may be manually specified or derived from the object the Spec
+        represents.
+        """
+        return self._name
+
+    def get_full_name(self) -> str:
+        """Get the full name of the spec.
+
+        Full name includes the module name of the object the Spec represents,
+        if available.
+        """
+        name = self._name
+        module_name = self._module_name
+        return f"{module_name}.{name}" if module_name else name
+
+    def get_signature(self) -> Optional[inspect.Signature]:
+        """Get the Spec's signature, if Spec represents a callable."""
+        try:
+            return inspect.signature(self._source)  # type: ignore[arg-type]
+        except TypeError:
+            return None
+
+    def get_class_type(self) -> Optional[Type[Any]]:
+        """Get the Spec's class type, if Spec represents a class."""
+        return self._source if inspect.isclass(self._source) else None
+
+    def get_is_async(self) -> bool:
+        """Get whether the Spec represents an async. callable."""
+        source = self._source
+
+        # `iscoroutinefunction` does not work for `partial` on Python < 3.8
+        if isinstance(source, functools.partial):
+            source = source.func
+
+        elif inspect.isclass(source):
+            call_method = inspect.getattr_static(source, "__call__", None)
+
+            if call_method is not None:
+                source = call_method
+
+        return inspect.iscoroutinefunction(source)
+
+    def bind_args(self, *args: Any, **kwargs: Any) -> BoundArgs:
+        """Bind given args and kwargs to the Spec's signature, if possible.
+
+        If no signature or unable to bind, will simply pass args and kwargs
+        through without modification.
+        """
+        signature = self.get_signature()
+
+        if signature:
+            try:
+                bound_args = signature.bind(*args, **kwargs)
+            except TypeError as e:
+                # stacklevel: 4 ensures warning is linked to call location
+                warnings.warn(IncorrectCallWarning(e), stacklevel=4)
+            else:
+                args = bound_args.args
+                kwargs = bound_args.kwargs
+
+        return BoundArgs(args=args, kwargs=kwargs)
+
+    def get_child_spec(self, name: str) -> "Spec":
+        """Get a child attribute, property, or method's Spec from this Spec."""
+        source = self._source
+        child_name = f"{self._name}.{name}"
+        child_source = None
+
+        if inspect.isclass(source):
+            # use type hints to get child spec for class attributes
+            child_hint = _get_type_hints(source).get(name)
+            # use inspect to get child spec for methods and properties
+            child_source = inspect.getattr_static(source, name, child_hint)
+
+            if isinstance(child_source, property):
+                child_source = _get_type_hints(child_source.fget).get("return")
+
+            elif isinstance(child_source, staticmethod):
+                child_source = child_source.__func__
+
+            elif inspect.isfunction(child_source):
+                # consume the `self` argument of the method to ensure proper
+                # signature reporting by wrapping it in a partial
+                child_source = functools.partial(child_source, None)
+
+        return Spec(source=child_source, name=child_name, module_name=self._module_name)
+
+
+def _get_type_hints(obj: Any) -> Dict[str, Any]:
+    """Get type hints for an object, if possible.
+
+    The builtin `typing.get_type_hints` may fail at runtime,
+    e.g. if a type is subscriptable according to mypy but not
+    according to Python.
+    """
+    try:
+        return get_type_hints(obj)
+    except Exception:
+        return {}

--- a/decoy/spec.py
+++ b/decoy/spec.py
@@ -27,7 +27,7 @@ class Spec:
 
     """
 
-    _DEFAULT_SPY_NAME = "spy"
+    _DEFAULT_SPY_NAME = "unnamed"
 
     def __init__(
         self,

--- a/decoy/spy_log.py
+++ b/decoy/spy_log.py
@@ -1,15 +1,14 @@
-"""Spy creation and storage."""
+"""Spy activity log."""
 from typing import List, Sequence
 
-from .spy_calls import BaseSpyCall, SpyCall, WhenRehearsal, VerifyRehearsal
 from .errors import MissingRehearsalError
+from .spy_calls import BaseSpyCall, SpyCall, WhenRehearsal, VerifyRehearsal
 
 
-class CallStack:
-    """SpyCall stack for all Spies in the Decoy container."""
+class SpyLog:
+    """Log of all Spy activities in the Decoy container."""
 
     def __init__(self) -> None:
-        """Initialize a stack for all SpyCalls."""
         self._stack: List[BaseSpyCall] = []
 
     def push(self, spy_call: SpyCall) -> None:

--- a/decoy/stub_store.py
+++ b/decoy/stub_store.py
@@ -28,11 +28,15 @@ class StubStore:
         """Initialize a StubStore with an empty stubbings list."""
         self._stubs: List[StubEntry] = []
 
-    def add(self, rehearsal: WhenRehearsal, behavior: StubBehavior) -> None:
+    def add(
+        self,
+        rehearsal: WhenRehearsal,
+        behavior: StubBehavior,
+    ) -> None:
         """Create and add a new StubBehavior to the store."""
         self._stubs.append(StubEntry(rehearsal=rehearsal, behavior=behavior))
 
-    def get_by_call(self, call: SpyCall) -> StubBehavior:
+    def get_by_call(self, call: SpyCall) -> Optional[StubBehavior]:
         """Get the latest StubBehavior matching this call."""
         reversed_indices = range(len(self._stubs) - 1, -1, -1)
 
@@ -45,7 +49,7 @@ class StubStore:
 
                 return stub.behavior
 
-        return StubBehavior()
+        return None
 
     def clear(self) -> None:
         """Remove all stored Stubs."""

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,9 @@
 # API Reference
 
 ::: decoy.Decoy
+    selection:
+        filters:
+            - "!^create_decoy"
 
 ::: decoy.Stub
 

--- a/docs/usage/verify.md
+++ b/docs/usage/verify.md
@@ -27,7 +27,9 @@ def test_my_thing(decoy: Decoy) -> None:
     subject = MyThing(database=database)
     subject.delete_model_by_id("some-id")
 
-    decoy.verify(database.remove("some-id"))
+    decoy.verify(
+        database.remove("some-id")  # <-- rehearsal
+    )
 ```
 
 If Decoy is unable to find any calls matching the rehearsal inside `verify`, a [decoy.errors.VerifyError][] will be raised.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Decoy
-site_description: "Opinionated, typed stubbing and verification library for Python."
+site_description: "Opinionated mocking library for Python."
 site_author: "Mike Cousins"
 site_url: "https://mike.cousins.io/decoy/"
 repo_url: "https://github.com/mcous/decoy"

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,11 @@ class SomeClass:
         """Get the bar bool based on a few inputs."""
         ...
 
+    @staticmethod
+    def fizzbuzz(hello: str) -> int:
+        """Fizz some buzzes."""
+        ...
+
     def do_the_thing(self, *, flag: bool) -> None:
         """Perform a side-effect without a return value."""
         ...
@@ -20,6 +25,8 @@ class SomeClass:
 
 class SomeNestedClass:
     """Nested testing class."""
+
+    child_attr: SomeClass
 
     def foo(self, val: str) -> str:
         """Get the foo string."""
@@ -44,6 +51,14 @@ class SomeAsyncClass:
 
     async def do_the_thing(self, *, flag: bool) -> None:
         """Perform a side-effect without a return value."""
+        ...
+
+
+class SomeAsyncCallableClass:
+    """Async callable class."""
+
+    async def __call__(self) -> int:
+        """Get an integer."""
         ...
 
 

--- a/tests/test_call_handler.py
+++ b/tests/test_call_handler.py
@@ -3,15 +3,15 @@ import pytest
 
 from decoy import Decoy
 from decoy.call_handler import CallHandler
-from decoy.call_stack import CallStack
+from decoy.spy_log import SpyLog
 from decoy.spy_calls import SpyCall
 from decoy.stub_store import StubBehavior, StubStore
 
 
 @pytest.fixture()
-def call_stack(decoy: Decoy) -> CallStack:
-    """Get a mock instance of a CallStack."""
-    return decoy.mock(cls=CallStack)
+def spy_log(decoy: Decoy) -> SpyLog:
+    """Get a mock instance of a SpyLog."""
+    return decoy.mock(cls=SpyLog)
 
 
 @pytest.fixture()
@@ -23,37 +23,37 @@ def stub_store(decoy: Decoy) -> StubStore:
 @pytest.fixture()
 def subject(
     decoy: Decoy,
-    call_stack: CallStack,
+    spy_log: SpyLog,
     stub_store: StubStore,
 ) -> CallHandler:
     """Get a CallHandler instance with its dependencies mocked out."""
     return CallHandler(
-        call_stack=call_stack,
+        spy_log=spy_log,
         stub_store=stub_store,
     )
 
 
 def test_handle_call_with_no_stubbing(
     decoy: Decoy,
-    call_stack: CallStack,
+    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:
     """It should noop and add the call to the stack if no stubbing is configured."""
     spy_call = SpyCall(spy_id=42, spy_name="spy_name", args=(), kwargs={})
-    behavior = StubBehavior()
+    behavior = None
 
     decoy.when(stub_store.get_by_call(spy_call)).then_return(behavior)
 
     result = subject.handle(spy_call)
 
     assert result is None
-    decoy.verify(call_stack.push(spy_call))
+    decoy.verify(spy_log.push(spy_call))
 
 
 def test_handle_call_with_return(
     decoy: Decoy,
-    call_stack: CallStack,
+    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:
@@ -66,12 +66,12 @@ def test_handle_call_with_return(
     result = subject.handle(spy_call)
 
     assert result == "hello world"
-    decoy.verify(call_stack.push(spy_call))
+    decoy.verify(spy_log.push(spy_call))
 
 
 def test_handle_call_with_raise(
     decoy: Decoy,
-    call_stack: CallStack,
+    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:
@@ -84,12 +84,12 @@ def test_handle_call_with_raise(
     with pytest.raises(RuntimeError, match="oh no"):
         subject.handle(spy_call)
 
-    decoy.verify(call_stack.push(spy_call))
+    decoy.verify(spy_log.push(spy_call))
 
 
 def test_handle_call_with_action(
     decoy: Decoy,
-    call_stack: CallStack,
+    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:
@@ -108,7 +108,7 @@ def test_handle_call_with_action(
 
 def test_handle_call_with_context_enter(
     decoy: Decoy,
-    call_stack: CallStack,
+    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:
@@ -121,4 +121,4 @@ def test_handle_call_with_context_enter(
     with subject.handle(spy_call) as result:
         assert result == "hello world"
 
-    decoy.verify(call_stack.push(spy_call))
+    decoy.verify(spy_log.push(spy_call))

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -37,8 +37,8 @@ class GetNameSpec(NamedTuple):
     [
         GetNameSpec(
             subject=Spec(source=None, name=None),
-            expected_name="spy",
-            expected_full_name="spy",
+            expected_name="unnamed",
+            expected_full_name="unnamed",
         ),
         GetNameSpec(
             subject=Spec(source=some_func, name=None),

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,318 @@
+"""Tests for Spec instances."""
+import pytest
+import inspect
+from typing import Any, Dict, NamedTuple, Optional, Tuple, Type
+
+from decoy.spec import Spec, BoundArgs
+from decoy.warnings import IncorrectCallWarning
+from .common import (
+    SomeClass,
+    SomeAsyncClass,
+    SomeAsyncCallableClass,
+    SomeNestedClass,
+    some_func,
+    some_async_func,
+)
+
+
+def test_init() -> None:
+    """It should have default spec properties."""
+    subject = Spec(source=None, name=None)
+
+    assert subject.get_signature() is None
+    assert subject.get_class_type() is None
+    assert subject.get_is_async() is False
+
+
+class GetNameSpec(NamedTuple):
+    """Spec data to test get_name and get_full_name."""
+
+    subject: Spec
+    expected_name: str
+    expected_full_name: str
+
+
+@pytest.mark.parametrize(
+    GetNameSpec._fields,
+    [
+        GetNameSpec(
+            subject=Spec(source=None, name=None),
+            expected_name="spy",
+            expected_full_name="spy",
+        ),
+        GetNameSpec(
+            subject=Spec(source=some_func, name=None),
+            expected_name="some_func",
+            expected_full_name="tests.common.some_func",
+        ),
+        GetNameSpec(
+            subject=Spec(source=some_func, name="spy_name", module_name="module_name"),
+            expected_name="spy_name",
+            expected_full_name="module_name.spy_name",
+        ),
+        GetNameSpec(
+            subject=Spec(source=some_func, name="spy_name", module_name=None),
+            expected_name="spy_name",
+            expected_full_name="spy_name",
+        ),
+        GetNameSpec(
+            subject=Spec(source=SomeClass, name=None).get_child_spec("foo"),
+            expected_name="SomeClass.foo",
+            expected_full_name="tests.common.SomeClass.foo",
+        ),
+        GetNameSpec(
+            subject=(
+                Spec(source=SomeNestedClass, name=None)
+                .get_child_spec("child")
+                .get_child_spec("foo")
+            ),
+            expected_name="SomeNestedClass.child.foo",
+            expected_full_name="tests.common.SomeNestedClass.child.foo",
+        ),
+    ],
+)
+def test_get_name(subject: Spec, expected_name: str, expected_full_name: str) -> None:
+    """It should assign names from args or spec."""
+    assert subject.get_name() == expected_name
+    assert subject.get_full_name() == expected_full_name
+
+
+class GetSignatureSpec(NamedTuple):
+    """Spec data to test get_signature."""
+
+    subject: Spec
+    expected_signature: Optional[inspect.Signature]
+
+
+@pytest.mark.parametrize(
+    GetSignatureSpec._fields,
+    [
+        GetSignatureSpec(
+            subject=Spec(source=None, name=None),
+            expected_signature=None,
+        ),
+        GetSignatureSpec(
+            subject=Spec(source=some_func, name=None),
+            expected_signature=inspect.Signature(
+                parameters=[
+                    inspect.Parameter(
+                        name="val",
+                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=str,
+                    )
+                ],
+                return_annotation=str,
+            ),
+        ),
+        GetSignatureSpec(
+            subject=Spec(source=SomeClass, name=None).get_child_spec("foo"),
+            expected_signature=inspect.Signature(
+                parameters=[
+                    inspect.Parameter(
+                        name="val",
+                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=str,
+                    )
+                ],
+                return_annotation=str,
+            ),
+        ),
+        GetSignatureSpec(
+            subject=(
+                Spec(source=SomeNestedClass, name=None)
+                .get_child_spec("child")
+                .get_child_spec("foo")
+            ),
+            expected_signature=inspect.Signature(
+                parameters=[
+                    inspect.Parameter(
+                        name="val",
+                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=str,
+                    )
+                ],
+                return_annotation=str,
+            ),
+        ),
+        GetSignatureSpec(
+            subject=(
+                Spec(source=SomeNestedClass, name=None)
+                .get_child_spec("child_attr")
+                .get_child_spec("foo")
+            ),
+            expected_signature=inspect.Signature(
+                parameters=[
+                    inspect.Parameter(
+                        name="val",
+                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=str,
+                    )
+                ],
+                return_annotation=str,
+            ),
+        ),
+        GetSignatureSpec(
+            subject=Spec(source=SomeClass, name=None).get_child_spec("fizzbuzz"),
+            expected_signature=inspect.Signature(
+                parameters=[
+                    inspect.Parameter(
+                        name="hello",
+                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=str,
+                    )
+                ],
+                return_annotation=int,
+            ),
+        ),
+    ],
+)
+def test_get_signature(
+    subject: Spec,
+    expected_signature: Optional[inspect.Signature],
+) -> None:
+    """It should inspect the spec source's signature."""
+    assert subject.get_signature() == expected_signature
+
+
+@pytest.mark.filterwarnings("ignore:'NoneType' object is not subscriptable")
+def test_get_signature_no_type_hints() -> None:
+    """It should gracefully degrade if a class's type hints cannot be resolved."""
+
+    class _BadTypeHints:
+        _not_ok: "None[Any]"
+
+        def _ok(self, hello: str) -> None:
+            ...
+
+    subject = Spec(source=_BadTypeHints, name=None).get_child_spec("_ok")
+
+    assert subject.get_signature() == inspect.Signature(
+        parameters=[
+            inspect.Parameter(
+                name="hello",
+                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=str,
+            )
+        ],
+        return_annotation=None,
+    )
+
+
+class GetClassTypeSpec(NamedTuple):
+    """Spec data to test get_class_type."""
+
+    subject: Spec
+    expected_class_type: Optional[Type[Any]]
+
+
+@pytest.mark.parametrize(
+    GetClassTypeSpec._fields,
+    [
+        GetClassTypeSpec(
+            subject=Spec(source=None, name=None),
+            expected_class_type=None,
+        ),
+        GetClassTypeSpec(
+            subject=Spec(source=some_func, name=None),
+            expected_class_type=None,
+        ),
+        GetClassTypeSpec(
+            subject=Spec(source=SomeClass, name=None),
+            expected_class_type=SomeClass,
+        ),
+    ],
+)
+def test_get_class_type(subject: Spec, expected_class_type: Type[Any]) -> None:
+    """It should get the class type, if source is a class."""
+    assert subject.get_class_type() == expected_class_type
+
+
+class GetIsAsyncSpec(NamedTuple):
+    """Spec data to test get_is_async."""
+
+    subject: Spec
+    expected_is_async: bool
+
+
+@pytest.mark.parametrize(
+    GetIsAsyncSpec._fields,
+    [
+        GetIsAsyncSpec(
+            subject=Spec(source=None, name=None),
+            expected_is_async=False,
+        ),
+        GetIsAsyncSpec(
+            subject=Spec(source=some_func, name=None),
+            expected_is_async=False,
+        ),
+        GetIsAsyncSpec(
+            subject=Spec(source=SomeClass, name=None),
+            expected_is_async=False,
+        ),
+        GetIsAsyncSpec(
+            subject=Spec(source=some_async_func, name=None),
+            expected_is_async=True,
+        ),
+        GetIsAsyncSpec(
+            subject=Spec(source=SomeAsyncCallableClass, name=None),
+            expected_is_async=True,
+        ),
+        GetIsAsyncSpec(
+            subject=Spec(source=SomeAsyncClass, name=None).get_child_spec("foo"),
+            expected_is_async=True,
+        ),
+    ],
+)
+def test_get_is_async(subject: Spec, expected_is_async: bool) -> None:
+    """It should get whether the Spec represents an async callable."""
+    assert subject.get_is_async() is expected_is_async
+
+
+class GetBindArgsSpec(NamedTuple):
+    """Spec data to test bind_args."""
+
+    subject: Spec
+    input_args: Tuple[Any, ...]
+    input_kwargs: Dict[str, Any]
+    expected_args: Tuple[Any, ...]
+    expected_kwargs: Dict[str, Any]
+
+
+@pytest.mark.parametrize(
+    GetBindArgsSpec._fields,
+    [
+        GetBindArgsSpec(
+            subject=Spec(source=None, name=None),
+            input_args=(1, 2, 3),
+            input_kwargs={"four": "five", "six": "seven"},
+            expected_args=(1, 2, 3),
+            expected_kwargs={"four": "five", "six": "seven"},
+        ),
+        GetBindArgsSpec(
+            subject=Spec(source=some_func, name=None),
+            input_args=(),
+            input_kwargs={"val": "hello"},
+            expected_args=("hello",),
+            expected_kwargs={},
+        ),
+    ],
+)
+def test_bind_args(
+    subject: Spec,
+    input_args: Tuple[Any, ...],
+    input_kwargs: Dict[str, Any],
+    expected_args: Tuple[Any, ...],
+    expected_kwargs: Dict[str, Any],
+) -> None:
+    """It should bind arguments to the spec's callable signature."""
+    result = subject.bind_args(*input_args, **input_kwargs)
+
+    assert result == BoundArgs(args=expected_args, kwargs=expected_kwargs)
+
+
+def test_warn_if_called_incorrectly() -> None:
+    """It should trigger a warning if bound_args is called incorrectly."""
+    subject = Spec(source=some_func, name=None)
+
+    with pytest.warns(IncorrectCallWarning, match="missing a required argument"):
+        subject.bind_args(wrong_arg_name="1")

--- a/tests/test_spy_calls.py
+++ b/tests/test_spy_calls.py
@@ -1,6 +1,7 @@
 """Tests for the spy call values."""
 import pytest
 from typing import List, NamedTuple
+
 from decoy.spy_calls import SpyCall, BaseSpyRehearsal, match_call
 
 

--- a/tests/test_spy_log.py
+++ b/tests/test_spy_log.py
@@ -3,12 +3,12 @@ import pytest
 
 from decoy.errors import MissingRehearsalError
 from decoy.spy_calls import SpyCall, WhenRehearsal, VerifyRehearsal
-from decoy.call_stack import CallStack
+from decoy.spy_log import SpyLog
 
 
 def test_push_and_consume_when_rehearsal() -> None:
     """It should be able to push and pop from the stack."""
-    subject = CallStack()
+    subject = SpyLog()
     call = SpyCall(spy_id=42, spy_name="my_spy", args=(), kwargs={})
 
     subject.push(call)
@@ -20,7 +20,7 @@ def test_push_and_consume_when_rehearsal() -> None:
 
 def test_push_and_consume_when_rehearsal_ignore_extra_args() -> None:
     """It should be able to push and pop from the stack while ignoring extra args."""
-    subject = CallStack()
+    subject = SpyLog()
     call = SpyCall(spy_id=42, spy_name="my_spy", args=(), kwargs={})
 
     subject.push(call)
@@ -32,7 +32,7 @@ def test_push_and_consume_when_rehearsal_ignore_extra_args() -> None:
 
 def test_consume_when_rehearsal_raises_empty_error() -> None:
     """It should raise an error if the stack is empty on pop."""
-    subject = CallStack()
+    subject = SpyLog()
 
     with pytest.raises(MissingRehearsalError):
         subject.consume_when_rehearsal(ignore_extra_args=False)
@@ -47,7 +47,7 @@ def test_consume_when_rehearsal_raises_empty_error() -> None:
 
 def test_consume_verify_rehearsals() -> None:
     """It should be able to pop a slice off the stack, retaining order."""
-    subject = CallStack()
+    subject = SpyLog()
     call_1 = SpyCall(spy_id=1, spy_name="spy_1", args=(), kwargs={})
     call_2 = SpyCall(spy_id=2, spy_name="spy_2", args=(), kwargs={})
 
@@ -69,7 +69,7 @@ def test_consume_verify_rehearsals() -> None:
 
 def test_consume_verify_rehearsals_ignore_extra_args() -> None:
     """It should be able to pop a slice off the stack, retaining order."""
-    subject = CallStack()
+    subject = SpyLog()
     call_1 = SpyCall(spy_id=1, spy_name="spy_1", args=(), kwargs={})
     call_2 = SpyCall(spy_id=2, spy_name="spy_2", args=(), kwargs={})
 
@@ -89,7 +89,7 @@ def test_consume_verify_rehearsals_ignore_extra_args() -> None:
 
 def test_consume_verify_rehearsals_raises_error() -> None:
     """It should raise an error if the stack has too few members to pop a slice."""
-    subject = CallStack()
+    subject = SpyLog()
     call_1 = SpyCall(spy_id=1, spy_name="spy_1", args=(), kwargs={})
 
     subject.push(call_1)
@@ -100,7 +100,7 @@ def test_consume_verify_rehearsals_raises_error() -> None:
 
 def test_get_by_rehearsal() -> None:
     """It can get a list of calls made matching spy IDs of given rehearsals."""
-    subject = CallStack()
+    subject = SpyLog()
     call_1 = SpyCall(spy_id=101, spy_name="spy_1", args=(1,), kwargs={})
     call_2 = SpyCall(spy_id=101, spy_name="spy_1", args=(2,), kwargs={})
     call_3 = SpyCall(spy_id=202, spy_name="spy_2", args=(1,), kwargs={})
@@ -133,7 +133,7 @@ def test_get_by_rehearsal() -> None:
 
 def test_get_all() -> None:
     """It can get a list of all calls and rehearsals."""
-    subject = CallStack()
+    subject = SpyLog()
     call_1 = SpyCall(spy_id=101, spy_name="spy_1", args=(), kwargs={})
     call_2 = SpyCall(spy_id=101, spy_name="spy_1", args=(), kwargs={})
     call_3 = SpyCall(spy_id=202, spy_name="spy_2", args=(), kwargs={})
@@ -153,7 +153,7 @@ def test_get_all() -> None:
 
 def test_clear() -> None:
     """It can clear all calls and rehearsals."""
-    subject = CallStack()
+    subject = SpyLog()
     call_1 = SpyCall(spy_id=101, spy_name="spy_1", args=(), kwargs={})
     call_2 = SpyCall(spy_id=101, spy_name="spy_1", args=(), kwargs={})
     call_3 = SpyCall(spy_id=202, spy_name="spy_2", args=(), kwargs={})

--- a/tests/test_stub_store.py
+++ b/tests/test_stub_store.py
@@ -37,13 +37,13 @@ def test_get_by_call_prefers_latest() -> None:
 
 
 def test_get_by_call_empty() -> None:
-    """It should return a no-op StubBehavior if store is empty."""
+    """It should return None if store is empty."""
     subject = StubStore()
     result = subject.get_by_call(
         call=SpyCall(spy_id=42, spy_name="my_spy", args=(), kwargs={})
     )
 
-    assert result == StubBehavior()
+    assert result is None
 
 
 @pytest.mark.parametrize(
@@ -86,7 +86,7 @@ def test_get_by_call_no_match(call: SpyCall) -> None:
     subject.add(rehearsal=rehearsal, behavior=behavior)
 
     result = subject.get_by_call(call=call)
-    assert result == StubBehavior()
+    assert result is None
 
 
 def test_get_by_call_once_behavior() -> None:
@@ -107,7 +107,7 @@ def test_get_by_call_once_behavior() -> None:
         call=SpyCall(spy_id=42, spy_name="my_spy", args=(1, 2, 3), kwargs={})
     )
 
-    assert result == StubBehavior()
+    assert result is None
 
 
 def test_clear() -> None:
@@ -122,4 +122,4 @@ def test_clear() -> None:
 
     result = subject.get_by_call(call=call)
 
-    assert result == StubBehavior()
+    assert result is None


### PR DESCRIPTION
This PR started as work on #18. However, the `Spy` had built up a fair amount of complexity that made it difficult to add new features.

In advance of property access mocking, the PR moves most of the complexity to a new `Spec` class and reworks the `Spy` class to be more clearly a collaborator object.