### PR TITLE
fix(spy): ensure class signature uses __call__

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -57,7 +57,15 @@ class SomeAsyncClass:
 class SomeAsyncCallableClass:
     """Async callable class."""
 
-    async def __call__(self) -> int:
+    async def __call__(self, val: int) -> int:
+        """Get an integer."""
+        ...
+
+
+class SomeCallableClass:
+    """Async callable class."""
+
+    async def __call__(self, val: int) -> int:
         """Get an integer."""
         ...
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -9,6 +9,7 @@ from .common import (
     SomeClass,
     SomeAsyncClass,
     SomeAsyncCallableClass,
+    SomeCallableClass,
     SomeNestedClass,
     some_func,
     some_async_func,
@@ -159,6 +160,19 @@ class GetSignatureSpec(NamedTuple):
                         name="hello",
                         kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
                         annotation=str,
+                    )
+                ],
+                return_annotation=int,
+            ),
+        ),
+        GetSignatureSpec(
+            subject=Spec(source=SomeCallableClass, name=None),
+            expected_signature=inspect.Signature(
+                parameters=[
+                    inspect.Parameter(
+                        name="val",
+                        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=int,
                     )
                 ],
                 return_annotation=int,


### PR DESCRIPTION
Mocks of callable classes (classes with `__call__` methods defined) were producing incorrect signatures: the signature of `__init__` rather than `__call__` would be used.

This PR fixes that issue. As a side effect, the Decoy test suite will no longer produce `IncorrectCallWarning`s on Python >= 3.9.