### PR TITLE
fix(spy): handle properties that return primitive types

### DIFF
--- a/decoy/spec.py
+++ b/decoy/spec.py
@@ -75,7 +75,7 @@ class Spec:
 
         try:
             return inspect.signature(source)
-        except TypeError:
+        except (ValueError, TypeError):
             return None
 
     def get_class_type(self) -> Optional[Type[Any]]:

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,6 +22,11 @@ class SomeClass:
         """Perform a side-effect without a return value."""
         ...
 
+    @property
+    def primitive_property(self) -> str:
+        """Get a primitive computed property."""
+        ...
+
 
 class SomeNestedClass:
     """Nested testing class."""

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -119,6 +119,12 @@ class GetSignatureSpec(NamedTuple):
             ),
         ),
         GetSignatureSpec(
+            subject=Spec(source=SomeClass, name=None).get_child_spec(
+                "primitive_property"
+            ),
+            expected_signature=None,
+        ),
+        GetSignatureSpec(
             subject=(
                 Spec(source=SomeNestedClass, name=None)
                 .get_child_spec("child")


### PR DESCRIPTION
Trying to get the signature of an `@property` that is typed with something like `int` or `str` will cause decoy to raise an error from `inspect.signature`. This PR fixes that issue.

This was a regression introduced in #108 which narrowed the `except` around `inspect.signature` from `Exception` to `TypeError`. As stated in the Python docs, [`inspect.signature`](https://docs.python.org/3/library/inspect.html#inspect.signature):

> Raises [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError) if no signature can be provided, and [TypeError](https://docs.python.org/3/library/exceptions.html#TypeError) if that type of object is not supported.