### PR TITLE
docs(readme): update URL for build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <p>Opinionated mocking library for Python</p>
     <p>
         <a title="CI Status" href="https://github.com/mcous/decoy/actions">
-        <img src="https://img.shields.io/github/workflow/status/mcous/decoy/Continuous%20integration/main?style=flat-square"></a>
+        <img src="https://img.shields.io/github/actions/workflow/status/mcous/decoy/ci.yml?branch=main&style=flat-square"></a>
         <a title="Code Coverage" href="https://app.codecov.io/gh/mcous/decoy/"><img src="https://img.shields.io/codecov/c/github/mcous/decoy?style=flat-square"></a>
         <a title="License" href="https://github.com/mcous/decoy/blob/main/LICENSE"><img src="https://img.shields.io/github/license/mcous/decoy?style=flat-square"></a>
         <a title="PyPI Version"href="https://pypi.org/project/decoy/"><img src="https://img.shields.io/pypi/v/decoy?style=flat-square"></a>


### PR DESCRIPTION
The build status badge in the readme is currently showing an error, apparently because of a (reasonable) breaking change in the https://shields.io service. This PR attempts to fix it according to the instructions in badges/shields#8671.