### PR TITLE
fix(warnings): trigger `reset` warnings at a better stack level

### DIFF
--- a/decoy/warning_checker.py
+++ b/decoy/warning_checker.py
@@ -10,7 +10,7 @@ from .spy_events import (
     WhenRehearsal,
     match_event,
 )
-from .warnings import MiscalledStubWarning, RedundantVerifyWarning
+from .warnings import DecoyWarning, MiscalledStubWarning, RedundantVerifyWarning
 
 
 class WarningChecker:
@@ -57,9 +57,9 @@ def _check_no_miscalled_stubs(all_events: Sequence[AnySpyEvent]) -> None:
             ):
                 unmatched = [*unmatched, call]
                 if index == len(spy_calls) - 1:
-                    warn(MiscalledStubWarning(calls=unmatched, rehearsals=past_stubs))
+                    _warn(MiscalledStubWarning(calls=unmatched, rehearsals=past_stubs))
             elif isinstance(call, WhenRehearsal) and len(unmatched) > 0:
-                warn(MiscalledStubWarning(calls=unmatched, rehearsals=past_stubs))
+                _warn(MiscalledStubWarning(calls=unmatched, rehearsals=past_stubs))
                 unmatched = []
 
 
@@ -69,4 +69,8 @@ def _check_no_redundant_verify(all_calls: Sequence[AnySpyEvent]) -> None:
 
     for vr in verify_rehearsals:
         if any(wr for wr in when_rehearsals if wr == vr):
-            warn(RedundantVerifyWarning(rehearsal=vr))
+            _warn(RedundantVerifyWarning(rehearsal=vr))
+
+def _warn(warning: DecoyWarning) -> None:
+    """Trigger a warning, at the stack level of whatever called `Decoy.reset`."""
+    warn(warning, stacklevel=6)


### PR DESCRIPTION
#164 upgraded ruff to include more flake8 bugbear errors, which highlighted that the `stacklevel` argument to `warnings.warn` is not used by the warning checker. This results in warnings being attached to an unhelpful decoy-internal call-site.

This PR uses the `stacklevel` argument of `warnings.warn` to trigger the warnings at whatever level called `decoy.reset`. For pytest usage, this results in something like the following:

```shell
# before
/Users/mc/projects/decoy/decoy/warning_checker.py:60: MiscalledStubWarning: Stub was called but no matching rehearsal found.
Found 1 rehearsal:
1.	stub(1, 2, 3)
Found 1 call:
1.	stub(4, 5, 6)
  warn(MiscalledStubWarning(calls=unmatched, rehearsals=past_stubs))

# after
/Users/mc/projects/decoy/decoy/pytest_plugin.py:32: MiscalledStubWarning: Stub was called but no matching rehearsal found.
Found 1 rehearsal:
1.	stub(1, 2, 3)
Found 1 call:
1.	stub(4, 5, 6)
  decoy.reset()
```