### PR TITLE
fix(spy): ensure __eq__ of rehearsal arg is preferred

### DIFF
--- a/decoy/spy_events.py
+++ b/decoy/spy_events.py
@@ -83,10 +83,10 @@ def match_event(event: AnySpyEvent, rehearsal: SpyRehearsal) -> bool:
 
         try:
             args_match = all(
-                call.args[i] == value for i, value in enumerate(rehearsed_call.args)
+                value == call.args[i] for i, value in enumerate(rehearsed_call.args)
             )
             kwargs_match = all(
-                call.kwargs[key] == value
+                value == call.kwargs[key]
                 for key, value in rehearsed_call.kwargs.items()
             )
 
@@ -95,4 +95,4 @@ def match_event(event: AnySpyEvent, rehearsal: SpyRehearsal) -> bool:
         except (IndexError, KeyError):
             return False
 
-    return event.payload == rehearsal.payload
+    return rehearsal.payload == event.payload


### PR DESCRIPTION
## Overview

Thanks to #200, we found a bug in how rehearsals are compared to actual calls. Previously, the check looked something like:

```py
if call_arg == rehearsal_arg:
     ...
```

This ordering gives preference to `call_arg.__eq__` if it exists, which means if `rehearsal_arg` is a matcher, `rehearsal_arg.__eq__` isn't used. Oops!

## Changelog

- Switch order of rehearsal <> call comparisons so rehearsals are always on the left side, giving their `__eq__` methods priority, if they exist