### PR TITLE
refactor(warnings): rework MiscalledStubWarning checker for clarity

### DIFF
--- a/decoy/warnings.py
+++ b/decoy/warnings.py
@@ -7,7 +7,7 @@ See the [warnings guide][] for more details.
 import os
 from typing import Sequence
 
-from .spy_events import SpyEvent, WhenRehearsal, VerifyRehearsal
+from .spy_events import SpyEvent, SpyRehearsal, VerifyRehearsal
 from .stringify import stringify_call, stringify_error_message, count
 
 
@@ -34,12 +34,12 @@ class MiscalledStubWarning(DecoyWarning):
         calls: Actual calls to the mock.
     """
 
-    rehearsals: Sequence[WhenRehearsal]
+    rehearsals: Sequence[SpyRehearsal]
     calls: Sequence[SpyEvent]
 
     def __init__(
         self,
-        rehearsals: Sequence[WhenRehearsal],
+        rehearsals: Sequence[SpyRehearsal],
         calls: Sequence[SpyEvent],
     ) -> None:
         heading = os.linesep.join(

--- a/tests/test_call_handler.py
+++ b/tests/test_call_handler.py
@@ -21,11 +21,7 @@ def stub_store(decoy: Decoy) -> StubStore:
 
 
 @pytest.fixture()
-def subject(
-    decoy: Decoy,
-    spy_log: SpyLog,
-    stub_store: StubStore,
-) -> CallHandler:
+def subject(spy_log: SpyLog, stub_store: StubStore) -> CallHandler:
     """Get a CallHandler instance with its dependencies mocked out."""
     return CallHandler(
         spy_log=spy_log,
@@ -98,7 +94,6 @@ def test_handle_call_with_raise(
 
 def test_handle_call_with_action(
     decoy: Decoy,
-    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:
@@ -120,7 +115,6 @@ def test_handle_call_with_action(
 
 def test_handle_prop_get_with_action(
     decoy: Decoy,
-    spy_log: SpyLog,
     stub_store: StubStore,
     subject: CallHandler,
 ) -> None:


### PR DESCRIPTION
#204 raised a couple questions about when Decoy chooses to emit errors and warnings, one of which is addressed by #218. The second question asks:

> [Should Decoy complain if] we try calling a method that is part of the mocked spec which is not mocked?

Currently, Decoy will not complain in this scenario. It will issue a `MiscalledStubWarning` if and only if the mock in question is used at least once with `decoy.when`, which acts as a marker for a test to say "I care about this dependency". This PR comes out of an investigation into the feasibility of enabling a `MiscalledStubWarning` even if the mock is fully unconfigured. In the course of answering this question:

- I reworked this portion of the warning checker
- **I decided the answer is still no**

Issuing a warning in this case forces every test using given subject to `decoy.when` or `decoy.verify` every single dependency the subject uses, even if a particular test isn't concerned with that behavior. In Decoy's own test suite this would trigger 8 warnings, and "fixing" those warnings would bloat the tests in question without providing meaningful design feedback
