### PR TITLE
feat(matchers): add `AnythingOrNone` to match any value including `None`

### DIFF
--- a/decoy/matchers.py
+++ b/decoy/matchers.py
@@ -41,6 +41,27 @@ __all__ = [
 ]
 
 
+class _AnythingOrNone:
+    def __eq__(self, target: object) -> bool:
+        return True
+
+    def __repr__(self) -> str:
+        """Return a string representation of the matcher."""
+        return "<AnythingOrNone>"
+
+
+def AnythingOrNone() -> Any:
+    """Match anything including None.
+
+    !!! example
+        ```python
+        assert "foobar" == AnythingOrNone()
+        assert None == AnythingOrNone()
+        ```
+    """
+    return _AnythingOrNone()
+
+
 class _Anything:
     def __eq__(self, target: object) -> bool:
         """Return true if target is not None."""

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -18,6 +18,19 @@ class _HelloClass(NamedTuple):
 _HelloTuple = namedtuple("_HelloTuple", ["hello"])
 
 
+def test_anything_or_none_matcher() -> None:
+    """It should have an "anything including None" matcher."""
+    assert 1 == matchers.AnythingOrNone()
+    assert False == matchers.AnythingOrNone()  # noqa: E712
+    assert {} == matchers.AnythingOrNone()
+    assert [] == matchers.AnythingOrNone()
+    assert ("hello", "world") == matchers.AnythingOrNone()
+    assert SomeClass() == matchers.AnythingOrNone()
+    assert None == matchers.AnythingOrNone()
+
+    assert str(matchers.AnythingOrNone()) == "<AnythingOrNone>"
+
+
 def test_any_matcher() -> None:
     """It should have an "anything except None" matcher."""
     assert 1 == matchers.Anything()
@@ -26,6 +39,7 @@ def test_any_matcher() -> None:
     assert [] == matchers.Anything()
     assert ("hello", "world") == matchers.Anything()
     assert SomeClass() == matchers.Anything()
+    assert None != matchers.Anything()
 
 
 def test_is_a_matcher() -> None:

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -26,7 +26,7 @@ def test_anything_or_none_matcher() -> None:
     assert [] == matchers.AnythingOrNone()
     assert ("hello", "world") == matchers.AnythingOrNone()
     assert SomeClass() == matchers.AnythingOrNone()
-    assert None == matchers.AnythingOrNone()
+    assert None is matchers.AnythingOrNone()
 
     assert str(matchers.AnythingOrNone()) == "<AnythingOrNone>"
 
@@ -39,7 +39,7 @@ def test_any_matcher() -> None:
     assert [] == matchers.Anything()
     assert ("hello", "world") == matchers.Anything()
     assert SomeClass() == matchers.Anything()
-    assert None != matchers.Anything()
+    assert None is not matchers.Anything()
 
 
 def test_is_a_matcher() -> None:

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -26,7 +26,7 @@ def test_anything_or_none_matcher() -> None:
     assert [] == matchers.AnythingOrNone()
     assert ("hello", "world") == matchers.AnythingOrNone()
     assert SomeClass() == matchers.AnythingOrNone()
-    assert None is matchers.AnythingOrNone()
+    assert None == matchers.AnythingOrNone()  # noqa: E711
 
     assert str(matchers.AnythingOrNone()) == "<AnythingOrNone>"
 
@@ -39,7 +39,7 @@ def test_any_matcher() -> None:
     assert [] == matchers.Anything()
     assert ("hello", "world") == matchers.Anything()
     assert SomeClass() == matchers.Anything()
-    assert None is not matchers.Anything()
+    assert None != matchers.Anything()  # noqa: E711
 
 
 def test_is_a_matcher() -> None:


### PR DESCRIPTION
When using decoy.when across multiple test cases, you may want the mock to return a result regardless of the argument values—even if some are None. To handle all combinations, you'd typically need to define multiple matchers like:
```
decoy.when(
    mock_instance.execute(
        arg1=matchers.Anything(),
        arg2=None,
    )
).then_return(self.some_result)
decoy.when(
    mock_instance.execute(
        arg1=matchers.Anything(),
        arg2=matchers.Anything(),
    )
).then_return(self.some_result)
decoy.when(
    mock_instance.execute(
        arg1=None,
        arg2=matchers.Anything(),
    )
).then_return(self.some_result)
```

This can be simplified by using a matcher that accepts both None and any value:
```
decoy.when(
    mock_instance.execute(
        arg1=matchers.AnythingOrNone(),
        arg2=matchers.AnythingOrNone(),
    )
).then_return(self.some_result)
```