### PR TITLE
fix(warnings): remove faulty `MissingSpecAttributeWarning`

### DIFF
--- a/decoy/warnings.py
+++ b/decoy/warnings.py
@@ -96,13 +96,3 @@ class IncorrectCallWarning(DecoyWarning):
 
     [IncorrectCallWarning guide]: usage/errors-and-warnings.md#incorrectcallwarning
     """
-
-
-class MissingSpecAttributeWarning(DecoyWarning):
-    """A warning raised if a Decoy mock with a spec is used with a missing attribute.
-
-    This will become an error in the next major version of Decoy.
-    See the [MissingSpecAttributeWarning guide][] for more details.
-
-    [MissingSpecAttributeWarning guide]: usage/errors-and-warnings.md#missingspecattributewarning
-    """

--- a/docs/usage/errors-and-warnings.md
+++ b/docs/usage/errors-and-warnings.md
@@ -80,8 +80,8 @@ pytestmark = pytest.mark.filterwarnings("ignore::decoy.warnings.DecoyWarning")
 
 A [decoy.warnings.MiscalledStubWarning][] is a warning provided mostly for productivity convenience. If you configure a stub but your code under test calls the stub incorrectly, it can sometimes be difficult to immediately figure out what went wrong. This warning exists to alert you if:
 
--   A mock has at least 1 stubbing configured with [decoy.Decoy.when][]
--   A call was made to the mock that didn't match any configured stubbing
+- A mock has at least 1 stubbing configured with [decoy.Decoy.when][]
+- A call was made to the mock that didn't match any configured stubbing
 
 In the example below, our test subject is supposed to call a `DataGetter` dependency and pass the output data into a `DataHandler` dependency to get the result. However, in writing `Subject.get_and_handle_data`, we forgot to pass `data_id` into `DataGetter.get`.
 
@@ -199,28 +199,4 @@ spy("hello")                # ok
 spy(val="world")            # ok
 spy(wrong_name="ah!")       # triggers an IncorrectCallWarning
 spy("too", "many", "args")  # triggers an IncorrectCallWarning
-```
-
-### MissingSpecAttributeWarning
-
-If you provide a Decoy mock with a specification `cls` or `func` and you attempt to access an attribute of the mock that does not exist on the specification, Decoy will raise a [decoy.warnings.MissingSpecAttributeWarning][].
-
-While Decoy will merely issue a warning, this call would likely cause the Python engine to error at runtime and should not be ignored. In the next major version of Decoy, this warning will become an error.
-
-```python
-class SomeClass:
-    def foo(self, val: str) -> str:
-        ...
-
-def some_func(val: string) -> int:
-    ...
-
-class_spy = decoy.mock(cls=SomeClass)
-func_spy = decoy.mock(func=some_func)
-
-class_spy.foo("hello")  # ok
-class_spy.bar("world")  # triggers a MissingSpecAttributeWarning
-
-func_spy("hello")       # ok
-func_spy.foo("world")   # triggers a MissingSpecAttributeWarning
 ```

--- a/tests/test_spy_core.py
+++ b/tests/test_spy_core.py
@@ -2,11 +2,10 @@
 
 import pytest
 import inspect
-import warnings
 from typing import Any, Dict, NamedTuple, Optional, Tuple, Type
 
 from decoy.spy_core import SpyCore, BoundArgs
-from decoy.warnings import IncorrectCallWarning, MissingSpecAttributeWarning
+from decoy.warnings import IncorrectCallWarning
 from .fixtures import (
     SomeClass,
     SomeAsyncClass,
@@ -440,70 +439,3 @@ def test_warn_if_called_incorrectly() -> None:
 
     with pytest.warns(IncorrectCallWarning, match="missing a required argument"):
         subject.bind_args(wrong_arg_name="1")
-
-
-def test_warn_if_spec_does_not_have_method() -> None:
-    """It should trigger a warning if bound_args is called incorrectly."""
-    class_subject = SpyCore(source=SomeClass, name=None)
-    nested_class_subject = SpyCore(source=SomeNestedClass, name=None)
-    func_subject = SpyCore(source=some_func, name=None)
-    specless_subject = SpyCore(source=None, name="anonymous")
-
-    # specless mocks and correct usage should not warn
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        specless_subject.create_child_core("foo", False)
-
-    # proper class usage should not warn
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        class_subject.create_child_core("foo", False)
-
-    # property access without types should not warn
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        class_subject.create_child_core("mystery_property", False)
-
-    # property access should be allowed through optionals
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        parent = nested_class_subject.create_child_core("optional_child", False)
-        parent.create_child_core("primitive_property", False)
-
-    # property access should be allowed through None unions
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        parent = nested_class_subject.create_child_core("union_none_child", False)
-        parent.create_child_core("primitive_property", False)
-
-    # property access should not be checked through unions
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        parent = nested_class_subject.create_child_core("union_child", False)
-        parent.create_child_core("who_knows", False)
-
-    # incorrect class usage should warn
-    with pytest.warns(
-        MissingSpecAttributeWarning, match="has no attribute 'this_is_wrong'"
-    ):
-        class_subject.create_child_core("this_is_wrong", False)
-
-    # incorrect function usage should warn
-    with pytest.warns(
-        MissingSpecAttributeWarning, match="has no attribute 'this_is_wrong'"
-    ):
-        func_subject.create_child_core("this_is_wrong", False)
-
-    # incorrect nested property usage should warn
-    with pytest.warns(
-        MissingSpecAttributeWarning, match="has no attribute 'this_is_wrong'"
-    ):
-        parent = nested_class_subject.create_child_core("optional_child", False)
-        parent.create_child_core("this_is_wrong", False)
-
-    # incorrect nested property usage should warn
-    with pytest.warns(
-        MissingSpecAttributeWarning, match="has no attribute 'this_is_wrong'"
-    ):
-        parent = nested_class_subject.create_child_core("union_none_child", False)
-        parent.create_child_core("this_is_wrong", False)


### PR DESCRIPTION
Closes #257

After attempting to scope `MissingSpecAttributeWarning` down to just method calls, I've decided that the point of the warning is fundamentally incompatible with how Decoy currently exists. Decoy mocks want to be extremely flexible spies, and I don't see a way to push attribute validation into that model in a way that won't produce false warnings. A static type-checker is a better tool for the job 

Accordingly, this PR removes `MissingSpecAttributeWarning` entirely. Given that this feature was always buggy, I've chosen to remove it under a patch release. Effectively reverts #218

