### PR TITLE
Add better static typing to matchers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ poetry run poe coverage
 
 In an exciting twist, since version 1.6.0, Decoy's tests rely on Decoy itself to test (and more importantly, design) the relationships between Decoy's internal APIs. This means:
 
--   Decoy's unit test suite serves as an end-to-end test of Decoy by virtue of existing (wow, very meta, actually kind of cool).
--   Changes that break a small part of Decoy may result in a large number of test failures, because if Decoy breaks it can't be used to test itself.
+- Decoy's unit test suite serves as an end-to-end test of Decoy by virtue of existing (wow, very meta, actually kind of cool).
+- Changes that break a small part of Decoy may result in a large number of test failures, because if Decoy breaks it can't be used to test itself.
 
 If you find yourself in a situation where Decoy's test suite has blown up, **concentrate on getting the test suites that don't use Decoy to pass**. From there, lean on the type-checker to guide you to any components that aren't properly hooked up. Decoy also has a end-to-end smoke test suite (`tests/test_decoy.py`) that can be helpful in getting things back to green.
 
@@ -61,7 +61,7 @@ poetry run poe format
 Decoy's documentation is built with [mkdocs][], which you can use to preview the documentation site locally.
 
 ```bash
-poetry run docs
+poetry run poe docs
 ```
 
 ## Deploying

--- a/docs/usage/matchers.md
+++ b/docs/usage/matchers.md
@@ -9,13 +9,14 @@ Decoy includes the [decoy.matchers][] module, which is a set of Python classes w
 | Matcher                           | Description                                          |
 | --------------------------------- | ---------------------------------------------------- |
 | [decoy.matchers.Anything][]       | Matches any value that isn't `None`                  |
+| [decoy.matchers.AnythingOrNone][] | Matches any value including `None`                   |
 | [decoy.matchers.DictMatching][]   | Matches a `dict` based on some of its values         |
 | [decoy.matchers.ErrorMatching][]  | Matches an `Exception` based on its type and message |
 | [decoy.matchers.HasAttributes][]  | Matches an object based on its attributes            |
 | [decoy.matchers.IsA][]            | Matches using `isinstance`                           |
 | [decoy.matchers.IsNot][]          | Matches anything that isn't a given value            |
 | [decoy.matchers.StringMatching][] | Matches a string against a regular expression        |
-| [decoy.matchers.Captor][]         | Captures the comparison value (see below)            |
+| [decoy.matchers.ArgumentCaptor][] | Captures the comparison value (see below)            |
 
 ## Basic usage
 
@@ -45,7 +46,11 @@ def test_log_warning(decoy: Decoy):
 
 ## Capturing values
 
-When testing certain APIs, especially callback APIs, it can be helpful to capture the values of arguments passed to a given dependency. For this, Decoy provides [decoy.matchers.Captor][].
+When testing certain APIs, especially callback APIs, it can be helpful to capture the values of arguments passed to a given dependency. For this, Decoy provides the [decoy.matchers.ArgumentCaptor][] matcher, which can be created with the [decoy.matchers.argument_captor][] function.
+
+!!! note
+
+    Prefer using [decoy.matchers.argument_captor][] to create a [decoy.matchers.ArgumentCaptor][] instance over the deprecated [decoy.matchers.Captor][]. The new function has better support for type checkers.
 
 For example, our test subject may register an event listener handler, and we want to test our subject's behavior when the event listener is triggered.
 
@@ -61,13 +66,13 @@ from .event_consumer import EventConsumer
 def test_event_listener(decoy: Decoy):
     event_source = decoy.mock(cls=EventSource)
     subject = EventConsumer(event_source=event_source)
-    captor = matchers.Captor()
+    captor = matchers.argument_captor()
 
     # subject registers its listener when started
     subject.start_consuming()
 
     # verify listener attached and capture the listener
-    decoy.verify(event_source.register(event_listener=captor))
+    decoy.verify(event_source.register(event_listener=captor.capture()))
 
     # trigger the listener
     event_handler = captor.value  # or, equivalently, captor.values[0]
@@ -77,7 +82,11 @@ def test_event_listener(decoy: Decoy):
     assert subject.has_heard_event is True
 ```
 
-This is a pretty verbose way of writing a test, so in general, you may want to approach using `matchers.Captor` as a form of potential code smell / test pain. There are often better ways to structure your code for these sorts of interactions that don't involve private functions.
+!!! tip
+
+    If you want to only capture values of a specific type, or you would like to have stricter type checking in your tests, consider passing a type to [decoy.matchers.argument_captor][] (e.g. `argument_captor(match_type=str)`).
+
+This is a pretty verbose way of writing a test, so in general, you may want to approach using `matchers.argument_captor` as a form of potential code smell / test pain. There are often better ways to structure your code for these sorts of interactions that don't involve private functions.
 
 For further reading on when (or rather, when not) to use argument captors, check out [testdouble's documentation on its argument captor matcher](https://github.com/testdouble/testdouble.js/blob/main/docs/6-verifying-invocations.md#tdmatcherscaptor).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "decoy"
-version = "2.2.0"
+version = "2.3.0"
 description = "Opinionated mocking library for Python"
 authors = ["Michael Cousins <michael@cousins.io>"]
 license = "MIT"

--- a/tests/typing/test_typing.yml
+++ b/tests/typing/test_typing.yml
@@ -108,25 +108,63 @@
       decoy.when(fake_any("hello")).then_enter_with(42)
 
   out: |
-      main:10: error: Invalid self argument "Stub\[int]" to attribute function "then_enter_with" with type "Callable\[\[Stub\[.*ContextManager\[ContextValueT]], ContextValueT], None]"  \[misc]
+      main:10: error: Invalid self argument "Stub\[int]" to attribute function "then_enter_with" with type "Callable\[\[Stub\[.*ContextManager\[ContextValueT, bool | None]], ContextValueT], None]"  \[misc]
       main:10: error: No overload variant of "then_enter_with" of "Stub" matches argument type "int"  \[call-overload]
       main:10: note: Possible overload variants:
       main:10: note:     def then_enter_with\(self, value.+\) -> None
 
-- case: matchers_mimic_types
+- case: matchers_mimic_types_when_not_passed_to_a_function
   main: |
       from decoy import matchers
 
+      captor = matchers.argument_captor()
+
       reveal_type(matchers.Anything())
+      reveal_type(matchers.AnythingOrNone())
       reveal_type(matchers.IsA(str))
-      reveal_type(matchers.IsNot(str))
+      reveal_type(matchers.IsNot(False))
+      reveal_type(matchers.HasAttributes({"foo": "bar"}))
+      reveal_type(matchers.DictMatching({"foo": 1}))
+      reveal_type(matchers.ListMatching([1]))
       reveal_type(matchers.StringMatching("foobar"))
       reveal_type(matchers.ErrorMatching(RuntimeError))
       reveal_type(matchers.Captor())
+      reveal_type(captor.capture())
+      reveal_type(captor.values)
   out: |
-      main:3: note: Revealed type is "Any"
-      main:4: note: Revealed type is "Any"
       main:5: note: Revealed type is "Any"
-      main:6: note: Revealed type is "builtins.str"
-      main:7: note: Revealed type is "builtins.RuntimeError"
-      main:8: note: Revealed type is "Any"
+      main:6: note: Revealed type is "Any"
+      main:7: note: Revealed type is "builtins.str"
+      main:8: note: Revealed type is "builtins.bool"
+      main:9: note: Revealed type is "Any"
+      main:10: note: Revealed type is "typing.Mapping[builtins.str, builtins.int]"
+      main:11: note: Revealed type is "builtins.list[builtins.int]"
+      main:12: note: Revealed type is "builtins.str"
+      main:13: note: Revealed type is "builtins.RuntimeError"
+      main:14: note: Revealed type is "Any"
+      main:15: note: Revealed type is "Any"
+      main:16: note: Revealed type is "builtins.list[Any]"
+
+- case: matchers_mimic_types_when_passed_to_a_function
+  main: |
+      from decoy import Decoy, matchers
+
+      class Dependency():
+          def do_thing(self, input: str) -> int:
+              return 42
+
+      decoy = Decoy()
+      fake = decoy.mock(cls=Dependency)
+      captor1 = matchers.argument_captor()
+      captor2 = matchers.argument_captor(str)
+      captor3 = matchers.argument_captor(int)
+
+      decoy.when(fake.do_thing(matchers.Anything())).then_return(42)
+      decoy.when(fake.do_thing(matchers.AnythingOrNone())).then_return(42)
+      decoy.when(fake.do_thing(matchers.HasAttributes({"foo": "bar"}))).then_return(42)
+      decoy.when(fake.do_thing(matchers.Captor())).then_return(42)
+      decoy.when(fake.do_thing(captor1.capture())).then_return(42)
+      decoy.when(fake.do_thing(captor2.capture())).then_return(42)
+      decoy.when(fake.do_thing(captor3.capture())).then_return(42)
+  out: |
+      main:19: error: Argument 1 to "do_thing" of "Dependency" has incompatible type "int"; expected "str"  [arg-type]


### PR DESCRIPTION
## Summary

Improve static typing support for argument matchers.

> Note: Feel free to suggest changes or deny the PR. I'm open for discussions.

## Motivation and context

One of the selling points of Decoy, at least for me, is its well-typed interface, which improves the developer experience. However, the typing of argument matchers falls a bit short in this regard. The previous implementation relied heavily on using `Any` as a return type, but it can be improved with the use of Generics.

## Description of changes

1. Change the `Captor` matcher to provide a typed interface for getting the captured values, instead of having to get them from an object of type `Any`. By separating the object used to get the captured values and the object passed as a matcher, we get a typed interface with better support for for auto-completions in the IDE. I've also added an optional parameter to specify the type to match. 

```python
from decoy import Decoy, matchers

class Dependency():
    def do_thing(self, input: str) -> int:
        return 42

decoy = Decoy()
fake = decoy.mock(cls=Dependency)

captor: ArgumentCaptor[Any] = matchers.argument_captor()
captor_typed: ArgumentCaptor[str] = matchers.argument_captor(str)

decoy.when(fake.do_thing(captor.capture())).then_return(42) # captor.capture() has type Any
decoy.when(fake.do_thing(captor_typed.capture())).then_return(42) # captor.capture() has type str

values: list[Any] = captor.values
values_typed: list[str] = captor_typed.values
```

2. On the other hand, I've changed the return type of matchers to use a generic type. For matchers without a clear expected type (like `Anything` or `HasAttributes`), I use a single generic type variable as the return type. 

  - For [pyright](https://github.com/microsoft/pyright?tab=readme-ov-file#static-type-checker-for-python) (which supports bidirectional inference), this means that the matcher infers the target type based on the context. See an [example here](https://pyright-play.net/?code=GYJw9gtgBALgngBwJYDsDmUkQWEMoAqiApgGoCGIANFAMbkDOMAUKwCbHBRtgD6MAC1RoAFKgQBXGAC4oTEAEooAWgB8mFDOZQoIYjAkgUUACwAmbVFa0ANowZReAQRRxBw6ZZ0cuvXsQBHPxEGYhtgGhhKNH1ZMAAjACtiWhglNSh4sDAbTx18-L0DI1ho-UwHFDB8ADkwFGJWAp9HXj0EEGDQ8PT1eTyCwv1DYwAiAB4XNyF0VVHWZgBZchhaAQIoAF5CEgoQEVHl1fXRmh9yCRsYTYTk1IUFlqn3dBFeqCO1ggGdIpG6RgwESfdY0ZyuF6iBQPVgAYigdSgxBA4BAADooM8ZlCNMBkQ5BMQoGApJJ8PAEET4oxiGxicZCXR6jBiAAPFg8fjYkRY4RvGHMeEAURRuAxAGFyCgqvh7Eg0MYAG6UJDkeI2IlgLgUokAA1uKRgutgYFgJCguvkuuY5C2mIh3IenMhInIDyAA). This approach is [used by Mockito in Java](https://github.com/mockito/mockito/blob/main/mockito-core/src/main/java/org/mockito/ArgumentMatchers.java#L140).

  - For [mypy](https://github.com/python/mypy?tab=readme-ov-file#mypy-static-typing-for-python), which is not capable of this type of inference (see an [example here](https://mypy-play.net/?mypy=latest&python=3.13&gist=c1fcbf2452fee21406f5593898944429)), the generic type is assigned its default value, which is `Any` for backwards compatibility. 

This change helps to remove errors and warnings of strict type checkers that report any usage of `Any`,  like [basedpyright](https://github.com/DetachHead/basedpyright?tab=readme-ov-file#-basedpyright).

## Testing

I have added both unit tests and type tests to verify the new expected behavior. I have also fixed a type test that was failing because of a syntax error.

## Documentation

I have updated the documentation with the new functionality. I have also fixed a couple of errors that I found.