### PR TITLE
feat(v3): add v3 migration codemod

### DIFF
--- a/codebook.toml
+++ b/codebook.toml
@@ -1,4 +1,5 @@
 words = [
+    "codemod",
     "matcher's",
     "matchers",
     "mock's",

--- a/decoy/codemods/__init__.py
+++ b/decoy/codemods/__init__.py
@@ -1,0 +1,1 @@
+"""Decoy codemods for automated upgrades and migrations."""

--- a/decoy/codemods/migrate.py
+++ b/decoy/codemods/migrate.py
@@ -1,0 +1,593 @@
+"""Migrate Decoy v2 usage to the v3 API."""
+
+from __future__ import annotations
+
+import enum
+from typing import Sequence, cast
+
+import libcst as cst
+from libcst import matchers as m
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+from libcst.metadata import (
+    Assignment,
+    BaseAssignment,
+    ParentNodeProvider,
+    Scope,
+    ScopeProvider,
+)
+
+
+class ImportAction(str, enum.Enum):
+    """Import migration type."""
+
+    KEEP = "keep"
+    NEXT = "next"
+    REMOVE = "remove"
+
+
+IMPORT_MIGRATIONS = {
+    "Decoy": ImportAction.NEXT,
+    "Prop": ImportAction.REMOVE,
+    "Stub": ImportAction.NEXT,
+    "errors": ImportAction.KEEP,
+    "warnings": ImportAction.KEEP,
+    "matchers": ImportAction.NEXT,
+}
+
+IMPORT_RENAMES = {"matchers": "Matcher"}
+
+
+class MigrateCommand(VisitorBasedCodemodCommand):
+    """Codemod to migrate to Decoy v3.
+
+    Only transforms calls on variables named `decoy`, `self.decoy`, or
+    `self._decoy`. Tests using a different variable name will need manual migration.
+
+    Only transforms matcher calls on the name `matchers`. Code using
+    `from decoy import matchers as m` will need manual migration.
+
+    Captor variables are migrated by name within their scope. If a captor variable
+    is rebound to a non-captor value, uses after the rebinding will still be
+    incorrectly migrated with `.arg`.
+    """
+
+    DESCRIPTION: str = "Migrate from Decoy v2 to Decoy v3 preview."
+
+    METADATA_DEPENDENCIES = (ParentNodeProvider, ScopeProvider)
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self._captor_assignments: set[BaseAssignment] = set()
+
+    @m.leave(
+        m.SimpleStatementLine(
+            body=[
+                m.ImportFrom(
+                    module=m.Name("decoy"),
+                    names=m.DoesNotMatch(m.ImportStar()),
+                )
+            ]
+        )
+    )
+    def migrate_import(
+        self,
+        original_node: cst.SimpleStatementLine,
+        updated_node: cst.SimpleStatementLine,
+    ) -> cst.SimpleStatementLine:
+        """Transform import statements from `decoy` to `decoy.next`."""
+        import_node = cst.ensure_type(updated_node.body[0], cst.ImportFrom)
+        import_aliases = cast(Sequence[cst.ImportAlias], import_node.names)
+
+        keep_imports = [
+            _migrate_alias(a, rename=False)
+            for a in import_aliases
+            if _import_action(a) == ImportAction.KEEP
+        ]
+        next_imports = [
+            _migrate_alias(a)
+            for a in import_aliases
+            if _import_action(a) == ImportAction.NEXT
+        ]
+
+        result: list[cst.SimpleStatementLine] = []
+
+        if keep_imports:
+            result.append(
+                cst.SimpleStatementLine(
+                    body=[import_node.with_changes(names=keep_imports)]
+                )
+            )
+
+        if next_imports:
+            result.append(
+                cst.SimpleStatementLine(
+                    body=[
+                        cst.ImportFrom(
+                            module=cst.Attribute(
+                                value=cst.Name("decoy"), attr=cst.Name("next")
+                            ),
+                            names=next_imports,
+                        )
+                    ]
+                )
+            )
+
+        return cast(cst.SimpleStatementLine, cst.FlattenSentinel(result))
+
+    @m.leave(
+        m.SimpleStatementLine(
+            body=[
+                m.Expr(
+                    value=m.Call(
+                        func=m.Attribute(
+                            value=(
+                                m.Name("decoy")
+                                | m.Attribute(
+                                    value=m.Name("self"),
+                                    attr=(m.Name("decoy") | m.Name("_decoy")),
+                                )
+                            ),
+                            attr=m.Name("verify"),
+                        ),
+                        args=[
+                            m.AtLeastN(
+                                n=2,
+                                matcher=(
+                                    m.Arg(
+                                        m.Call()
+                                        | m.Attribute()
+                                        | m.Await(m.Call() | m.Attribute())
+                                    )
+                                    | m.Arg(
+                                        m.BooleanOperation(
+                                            left=m.BooleanOperation(
+                                                left=m.DoNotCare(),  # condition
+                                                operator=m.And(),
+                                                right=m.List(),  # true branch
+                                            ),
+                                            operator=m.Or(),
+                                            right=m.List(),  # false branch
+                                        ),
+                                        star="*",
+                                    )
+                                ),
+                            ),
+                            m.ZeroOrMore(
+                                m.Arg(
+                                    keyword=(
+                                        m.Name("times") | m.Name("ignore_extra_args")
+                                    )
+                                )
+                            ),
+                        ],
+                    )
+                )
+            ]
+        )
+    )
+    def migrate_verify_order(
+        self,
+        original_node: cst.SimpleStatementLine,
+        updated_node: cst.SimpleStatementLine,
+    ) -> cst.SimpleStatementLine | cst.With:
+        """Transform multiple verify calls into verify_order context."""
+        expr = cst.ensure_type(updated_node.body[0], cst.Expr)
+        call = cst.ensure_type(expr.value, cst.Call)
+        attr = cst.ensure_type(call.func, cst.Attribute)
+
+        kwargs = [arg for arg in call.args if arg.keyword]
+
+        verify_statements: list[cst.BaseStatement] = [
+            _extract_conditional_starred_arg(arg.value, attr, kwargs)
+            if arg.star == "*"
+            else cst.SimpleStatementLine(
+                body=[cst.Expr(_migrate_rehearsal_stmt(attr, arg.value, kwargs))]
+            )
+            for arg in call.args
+            if not arg.keyword
+        ]
+
+        verify_order_call = cst.Call(
+            func=cst.Attribute(value=attr.value, attr=cst.Name("verify_order")),
+            args=[],
+        )
+
+        return cst.With(
+            items=[cst.WithItem(item=verify_order_call)],
+            body=cst.IndentedBlock(body=verify_statements),
+        )
+
+    @m.leave(
+        m.Call(
+            func=m.Attribute(
+                value=(
+                    m.Name("decoy")
+                    | m.Attribute(
+                        value=m.Name("self"),
+                        attr=(m.Name("decoy") | m.Name("_decoy")),
+                    )
+                ),
+                attr=(m.Name("when") | m.Name("verify")),
+            ),
+            args=[
+                m.Arg(m.Call() | m.Attribute() | m.Await(m.Call() | m.Attribute())),
+                m.ZeroOrMore(
+                    m.Arg(keyword=(m.Name("times") | m.Name("ignore_extra_args")))
+                ),
+            ],
+        )
+    )
+    def migrate_call(
+        self,
+        original_node: cst.Call,
+        updated_node: cst.Call,
+    ) -> cst.Call:
+        """Transform `decoy.when` and `decoy.verify` calls.
+
+        - `decoy.when(some_func(...))` -> `decoy.when(some_func).called_with(...)`
+        - `decoy.when(some.attr)` -> `decoy.when(some.attr).get()`
+        - `decoy.verify(some_func(...))` -> `decoy.verify(some_func).called_with(...)`
+        """
+        parent = self.get_metadata(ParentNodeProvider, original_node)
+
+        if m.matches(
+            parent,  # pyright: ignore[reportArgumentType]
+            m.Attribute(
+                attr=(
+                    m.Name("called_with")
+                    | m.Name("get")
+                    | m.Name("set")
+                    | m.Name("delete")
+                )
+            ),
+        ):
+            return updated_node
+
+        rehearsal = updated_node.args[0].value
+        kwargs = updated_node.args[1:]
+
+        if m.matches(rehearsal, m.Await()):
+            rehearsal = cst.ensure_type(rehearsal, cst.Await).expression
+
+        if m.matches(rehearsal, m.Attribute()):
+            return cst.Call(
+                func=cst.Attribute(value=updated_node, attr=cst.Name("get")),
+                args=[],
+            )
+
+        rehearsal = cst.ensure_type(rehearsal, cst.Call)
+
+        return _migrate_rehearsal(updated_node.func, rehearsal, kwargs)
+
+    @m.call_if_inside(m.Arg())
+    @m.leave(m.Call(func=m.Attribute(value=m.Name("matchers"))))
+    def migrate_matcher_arg(
+        self,
+        original_node: cst.Call,
+        updated_node: cst.Call,
+    ) -> cst.Attribute | cst.Call:
+        """Replace args using `matchers` with `Matcher` static methods."""
+        migrated = _migrate_matcher(updated_node)
+        if migrated is updated_node:
+            return updated_node
+        return cst.Attribute(value=migrated, attr=cst.Name("arg"))
+
+    @m.call_if_not_inside(m.Arg())
+    @m.leave(m.Call(func=m.Attribute(value=m.Name("matchers"))))
+    def migrate_matcher_call(
+        self,
+        original_node: cst.Call,
+        updated_node: cst.Call,
+    ) -> cst.Call:
+        """Replace args using `matchers` with `Matcher` static methods."""
+        return _migrate_matcher(updated_node)
+
+    @m.visit(
+        m.Assign(
+            value=m.Call(
+                func=m.Attribute(
+                    value=m.Name("matchers"),
+                    attr=(m.Name("Captor") | m.Name("ValueCaptor")),
+                )
+            )
+        )
+    )
+    def track_captor_assignment(self, node: cst.Assign) -> None:
+        """Find captor assignments to add `.arg`."""
+        scope = self._get_scope(node)
+        target_node_ids = {
+            id(target.target)
+            for target in node.targets
+            if m.matches(target.target, m.Name())
+        }
+        self._captor_assignments.update(
+            a
+            for a in scope.assignments  # pyright: ignore[reportAttributeAccessIssue]
+            if isinstance(a, Assignment) and id(a.node) in target_node_ids
+        )
+
+    @m.leave(
+        m.Arg(value=(m.Name() | m.Attribute(value=m.Name(), attr=m.Name("matcher"))))
+    )
+    def migrate_captor_arg(
+        self,
+        original_node: cst.Arg,
+        updated_node: cst.Arg,
+    ) -> cst.Arg:
+        """Add `.arg` when captor is used as function argument."""
+        name_node = (
+            cst.ensure_type(original_node.value, cst.Attribute).value
+            if m.matches(original_node.value, m.Attribute())
+            else original_node.value
+        )
+        updated_name_node = (
+            cst.ensure_type(updated_node.value, cst.Attribute).value
+            if m.matches(updated_node.value, m.Attribute())
+            else updated_node.value
+        )
+
+        name = cst.ensure_type(name_node, cst.Name).value
+        scope = self._get_scope(original_node.value)
+
+        if name in scope and any(  # pyright: ignore[reportOperatorIssue]
+            a in self._captor_assignments
+            for a in scope[name]  # pyright: ignore[reportIndexIssue]
+        ):
+            return updated_node.with_changes(
+                value=cst.Attribute(value=updated_name_node, attr=cst.Name("arg"))
+            )
+
+        return updated_node
+
+    def _get_scope(self, node: cst.CSTNode) -> Scope:
+        scope = self.get_metadata(ScopeProvider, node)
+        assert isinstance(scope, Scope)
+        return scope
+
+
+def _import_action(alias: cst.ImportAlias) -> ImportAction | None:
+    action = IMPORT_MIGRATIONS.get(alias.evaluated_name)
+    # matchers with an alias won't be fully migrated (matcher visitors hardcode
+    # the name `matchers`), so keep it in `decoy` to fail loudly in v3
+    if (
+        action == ImportAction.NEXT
+        and alias.evaluated_name == "matchers"
+        and alias.asname is not None
+    ):
+        return ImportAction.KEEP
+    return action
+
+
+def _migrate_alias(alias: cst.ImportAlias, rename: bool = True) -> cst.ImportAlias:
+    new_name = IMPORT_RENAMES.get(alias.evaluated_name) if rename else None
+    return alias.with_changes(
+        name=cst.Name(new_name) if new_name else alias.name,
+        comma=cst.MaybeSentinel.DEFAULT,
+    )
+
+
+def _migrate_rehearsal(
+    decoy_method: cst.BaseExpression,
+    rehearsal: cst.Call,
+    kwargs: Sequence[cst.Arg],
+) -> cst.Call:
+    if m.matches(
+        rehearsal,
+        m.Call(
+            func=m.Attribute(
+                value=m.Call(
+                    func=m.Attribute(
+                        value=(
+                            m.Name("decoy")
+                            | m.Attribute(
+                                value=m.Name("self"),
+                                attr=(m.Name("decoy") | m.Name("_decoy")),
+                            )
+                        ),
+                        attr=m.Name("prop"),
+                    ),
+                    args=[m.Arg(value=m.DoNotCare())],
+                ),
+                attr=(m.Name("set") | m.Name("delete")),
+            ),
+            args=[m.ZeroOrOne(m.DoNotCare())],
+        ),
+    ):
+        attribute_rehearsal = cst.ensure_type(rehearsal.func, cst.Attribute)
+        prop_call = cst.ensure_type(attribute_rehearsal.value, cst.Call)
+        mock = prop_call.args[0].value
+        match_method = attribute_rehearsal.attr
+
+    else:
+        mock = rehearsal.func
+        match_method = cst.Name("called_with")
+
+    return cst.Call(
+        func=cst.Attribute(
+            value=cst.Call(
+                func=decoy_method,
+                args=[cst.Arg(value=mock), *_clean_args(kwargs)],
+            ),
+            attr=match_method,
+        ),
+        args=_clean_args(rehearsal.args),
+    )
+
+
+def _extract_conditional_starred_arg(
+    value: cst.BaseExpression,
+    decoy_func: cst.Attribute,
+    kwargs: list[cst.Arg],
+) -> cst.If:
+    """Extract conditional from *(flag and [...] or [...])."""
+    bool_op = cst.ensure_type(value, cst.BooleanOperation)
+    left_bool_op = cst.ensure_type(bool_op.left, cst.BooleanOperation)
+
+    condition = left_bool_op.left
+    true_list = cst.ensure_type(left_bool_op.right, cst.List)
+    false_list = cst.ensure_type(bool_op.right, cst.List)
+
+    def _statements(
+        elements: Sequence[cst.BaseElement],
+    ) -> list[cst.SimpleStatementLine]:
+        return [
+            cst.SimpleStatementLine(
+                body=[
+                    cst.Expr(
+                        _migrate_rehearsal_stmt(
+                            decoy_func,
+                            cst.ensure_type(element, cst.Element).value,
+                            kwargs,
+                        )
+                    )
+                ]
+            )
+            for element in elements
+        ]
+
+    else_body = _statements(false_list.elements)
+
+    return cst.If(
+        test=condition,
+        body=cst.IndentedBlock(body=_statements(true_list.elements)),
+        orelse=cst.Else(body=cst.IndentedBlock(body=else_body)) if else_body else None,
+    )
+
+
+def _migrate_rehearsal_stmt(
+    decoy_method: cst.BaseExpression,
+    rehearsal: cst.BaseExpression,
+    kwargs: Sequence[cst.Arg],
+) -> cst.Call:
+    """Migrate a single rehearsal, handling both calls and bare attribute access."""
+    if m.matches(rehearsal, m.Await()):
+        rehearsal = cst.ensure_type(rehearsal, cst.Await).expression
+    if m.matches(rehearsal, m.Attribute()):
+        return cst.Call(
+            func=cst.Attribute(
+                value=cst.Call(
+                    func=decoy_method,
+                    args=[cst.Arg(value=rehearsal), *_clean_args(kwargs)],
+                ),
+                attr=cst.Name("get"),
+            ),
+            args=[],
+        )
+    return _migrate_rehearsal(
+        decoy_method, cst.ensure_type(rehearsal, cst.Call), kwargs
+    )
+
+
+def _migrate_matcher(original: cst.Call) -> cst.Call:
+    original_method = cst.ensure_type(original.func, cst.Attribute).attr.value
+    original_args = original.args
+    args: Sequence[cst.Arg | None] = original_args
+
+    if original_method in ("AnythingOrNone", "Captor", "ValueCaptor"):
+        renamed_method = "any"
+    elif original_method == "Anything":
+        renamed_method = "is_not"
+        args = [cst.Arg(value=cst.Name("None"))]
+    elif original_method == "IsA":
+        renamed_method = "any"
+        args = [
+            _find_kwarg(original_args, "match_type", "type")
+            or _rename_arg_at(
+                original_args, 0, keyword="type", only_if_positional=True
+            ),
+            _find_kwarg(original_args, "attributes", "attrs")
+            or _rename_arg_at(
+                original_args, 1, keyword="attrs", only_if_positional=True
+            ),
+        ]
+    elif original_method == "IsNot":
+        renamed_method = "is_not"
+    elif original_method == "HasAttributes":
+        renamed_method = "any"
+        args = [
+            _rename_arg_at(original_args, 0, keyword="attrs", force_use_keyword=True)
+        ]
+    elif original_method in ("DictMatching", "ListMatching"):
+        renamed_method = "contains"
+    elif original_method == "StringMatching":
+        renamed_method = "matches"
+    elif original_method == "ErrorMatching":
+        renamed_method = "error"
+        args = [
+            _find_kwarg(original_args, "error", "type")
+            or _rename_arg_at(
+                original_args, 0, keyword="type", only_if_positional=True
+            ),
+            _find_kwarg(original_args, "match", "match")
+            or _rename_arg_at(
+                original_args, 1, keyword="match", only_if_positional=True
+            ),
+        ]
+    else:
+        return original
+
+    return cst.Call(
+        func=cst.Attribute(value=cst.Name("Matcher"), attr=cst.Name(renamed_method)),
+        args=_clean_args(args),
+    )
+
+
+def _rename_arg_at(
+    original_args: Sequence[cst.Arg],
+    index: int,
+    keyword: str,
+    force_use_keyword: bool = False,
+    only_if_positional: bool = False,
+) -> cst.Arg | None:
+    if index >= len(original_args):
+        return None
+
+    original = original_args[index]
+
+    if only_if_positional and original.keyword is not None:
+        return None
+
+    use_keyword = original.keyword is not None or force_use_keyword
+
+    return cst.Arg(
+        value=original.value,
+        equal=(
+            cst.AssignEqual(
+                whitespace_before=cst.SimpleWhitespace(""),
+                whitespace_after=cst.SimpleWhitespace(""),
+            )
+            if use_keyword
+            else cst.MaybeSentinel.DEFAULT
+        ),
+        keyword=cst.Name(keyword) if use_keyword else None,
+    )
+
+
+def _find_kwarg(
+    original_args: Sequence[cst.Arg],
+    original_keyword: str,
+    new_keyword: str,
+) -> cst.Arg | None:
+    """Find an arg by its original keyword name and rename it."""
+    for arg in original_args:
+        if arg.keyword is not None and arg.keyword.value == original_keyword:
+            return cst.Arg(
+                value=arg.value,
+                keyword=cst.Name(new_keyword),
+                equal=cst.AssignEqual(
+                    whitespace_before=cst.SimpleWhitespace(""),
+                    whitespace_after=cst.SimpleWhitespace(""),
+                ),
+            )
+    return None
+
+
+def _clean_args(args: Sequence[cst.Arg | None]) -> list[cst.Arg]:
+    return [_clean_arg(arg) for arg in args if arg is not None]
+
+
+def _clean_arg(arg: cst.Arg) -> cst.Arg:
+    return arg.with_changes(
+        comma=cst.MaybeSentinel.DEFAULT,
+        whitespace_after_arg=cst.SimpleWhitespace(""),
+    )

--- a/decoy/codemods/pyproject.toml
+++ b/decoy/codemods/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+extend = "../../pyproject.toml"
+target-version = "py310"

--- a/decoy/next/pyproject.toml
+++ b/decoy/next/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+extend = "../../pyproject.toml"
+target-version = "py310"

--- a/docs/v3/migration.md
+++ b/docs/v3/migration.md
@@ -2,6 +2,7 @@
 
 Recommended migration from v2:
 
+0. Ensure you're running Python 3.10 or later.
 1. Upgrade to `decoy>=2.4.0 <3`.
 2. Incrementally migrate to the new API using `decoy.next`.
 3. Once all tests are using the v3 syntax, upgrade to `v3` and swap `decoy.next` with `decoy`.
@@ -9,6 +10,20 @@ Recommended migration from v2:
 !!! warning
 
     `v3` is not yet released. This migration guide will change as `v3` is finalized.
+
+## Codemod
+
+A [libcst][] codemod is available to automate the changes described in this guide. Run it against your project files with `uv`:
+
+```sh
+uv run --with libcst python -m libcst.tool codemod decoy.codemods.migrate.MigrateCommand .
+```
+
+!!! note
+
+    The codemod only transforms calls on variables named `decoy`, `self.decoy`, or `self._decoy`, and matcher calls on the name `matchers`. Code using different variable names will need manual migration.
+
+[libcst]: https://libcst.readthedocs.io/
 
 ## Setup
 
@@ -70,7 +85,7 @@ To verify a sequence of calls, call `Decoy.verify` from a [`Decoy.verify_order`]
 -     mock("b"),
 -     mock("c"),
 - )
-+ decoy.verify_order():
++ with decoy.verify_order():
 +   decoy.verify(mock).called_with("a")
 +   decoy.verify(mock).called_with("b")
 +   decoy.verify(mock).called_with("c")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dev = [
     "ruff (==0.14.10)",
     "mkdocs (==1.6.1) ; python_version >= '3.10'",
     "mkdocs-material (==9.7.1) ; python_version >= '3.10'",
-    "mkdocstrings[python] (==1.0.0) ; python_version >= '3.10'"
+    "mkdocstrings[python] (==1.0.0) ; python_version >= '3.10'",
+    "libcst>=1.0.1",
 ]
 
 [tool.poe]
@@ -100,7 +101,6 @@ show_error_codes = true
 exclude_lines = ["@overload", "if TYPE_CHECKING:", "# pragma: no cover"]
 
 [tool.ruff]
-target-version = "py37"
 extend-exclude = [".cache"]
 
 [tool.ruff.lint]
@@ -119,4 +119,4 @@ module-name = "decoy"
 module-root = ""
 
 [tool.uv]
-required-version = ">=0.9.21,<0.10.0"
+required-version = ">=0.9.21,<0.12.0"

--- a/tests/codemods/test_migrate.py
+++ b/tests/codemods/test_migrate.py
@@ -1,0 +1,717 @@
+"""Migration codemod tests."""
+
+import sys
+
+import pytest
+from libcst.codemod import CodemodTest
+
+if sys.version_info >= (3, 10):
+    from decoy.codemods.migrate import MigrateCommand
+else:
+    MigrateCommand = None
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="v3 preview only supports Python >= 3.10",
+)
+
+
+class TestMigrateCommand(CodemodTest):
+    """Tests for decoy.codemods.migrate."""
+
+    TRANSFORM = MigrateCommand
+
+    def test_import_decoy(self) -> None:
+        """Swap to `decoy.next` for main Decoy."""
+        before = """
+            from decoy import Decoy
+        """
+        after = """
+            from decoy.next import Decoy
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_import_decoy_star(self) -> None:
+        """Leave import star alone, since it would be too complicated to migrate."""
+        before = """
+            from decoy import *
+        """
+        after = """
+            from decoy import *
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_import_decoy_errors_and_warnings(self) -> None:
+        """Keep to errors and warnings from regular `decoy`."""
+        before = """
+            from decoy import Decoy, Stub, errors, warnings
+        """
+        after = """
+            from decoy import errors, warnings
+            from decoy.next import Decoy, Stub
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_import_remove_prop(self) -> None:
+        """Remove `Prop` import."""
+        before = """
+            from decoy import Prop
+        """
+        after = ""
+
+        self.assertCodemod(before, after)
+
+    def test_import_rename_matcher(self) -> None:
+        """Swap `matchers` to `Matcher` from `decoy.next`."""
+        before = """
+            from decoy import Decoy, matchers
+        """
+        after = """
+            from decoy.next import Decoy, Matcher
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_import_rename_matcher_aliased(self) -> None:
+        """Leave aliased `matchers` import in `decoy` to avoid silent breakage."""
+        before = """
+            from decoy import Decoy, matchers as m
+        """
+        after = """
+            from decoy import matchers as m
+            from decoy.next import Decoy
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_called_with(self) -> None:
+        """Swap when function rehearsal with `called_with`."""
+        before = """
+            decoy.when(some_func("hello", "world")).then_return(True)
+        """
+        after = """
+            decoy.when(some_func).called_with("hello", "world").then_return(True)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_called_with_on_self(self) -> None:
+        """Swap when function rehearsal with `called_with` from `self._decoy`."""
+        before = """
+            self._decoy.when(some_func("hello", "world")).then_return(True)
+            self.decoy.when(some_func("hello", "world")).then_return(True)
+        """
+        after = """
+            self._decoy.when(some_func).called_with("hello", "world").then_return(True)
+            self.decoy.when(some_func).called_with("hello", "world").then_return(True)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_called_with_idempotent(self) -> None:
+        """Does not touch `called_with` twice."""
+        before = """
+            decoy.when(some.func).called_with("hello").then_return(True)
+            decoy.when(some.func).get().then_return(True)
+            decoy.when(some.func).set("hello").then_raise(RuntimeError())
+            decoy.when(some.func).delete().then_raise(RuntimeError())
+        """
+        after = """
+            decoy.when(some.func).called_with("hello").then_return(True)
+            decoy.when(some.func).get().then_return(True)
+            decoy.when(some.func).set("hello").then_raise(RuntimeError())
+            decoy.when(some.func).delete().then_raise(RuntimeError())
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_called_with_extra_args(self) -> None:
+        """Swap when function rehearsal with `called_with`, keeping extra args."""
+        before = """
+            decoy.when(some_func("hello"), ignore_extra_args=True).then_return(True)
+        """
+        after = """
+            decoy.when(some_func, ignore_extra_args=True).called_with("hello").then_return(True)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_attribute_get(self) -> None:
+        """Swap attribute get rehearsal with `get`."""
+        before = """
+            decoy.when(mock.some_prop).then_return(True)
+        """
+        after = """
+            decoy.when(mock.some_prop).get().then_return(True)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_attribute_set(self) -> None:
+        """Swap attribute set rehearsal with `set`."""
+        before = """
+            decoy.when(decoy.prop(mock.some_prop).set(42)).then_raise(RuntimeError("oh no"))
+        """
+        after = """
+            decoy.when(mock.some_prop).set(42).then_raise(RuntimeError("oh no"))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_attribute_delete(self) -> None:
+        """Swap attribute delete rehearsal with `delete`."""
+        before = """
+            decoy.when(decoy.prop(mock.some_prop).delete()).then_raise(RuntimeError("oh no"))
+        """
+        after = """
+            decoy.when(mock.some_prop).delete().then_raise(RuntimeError("oh no"))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_attribute_set_on_self(self) -> None:
+        """Swap attribute set rehearsal using self.decoy.prop with `set`."""
+        before = """
+            self.decoy.when(self.decoy.prop(mock.some_prop).set(42)).then_raise(RuntimeError("oh no"))
+        """
+        after = """
+            self.decoy.when(mock.some_prop).set(42).then_raise(RuntimeError("oh no"))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_when_attribute_delete_on_self(self) -> None:
+        """Swap attribute delete rehearsal using self.decoy.prop with `delete`."""
+        before = """
+            self.decoy.when(self.decoy.prop(mock.some_prop).delete()).then_raise(RuntimeError("oh no"))
+        """
+        after = """
+            self.decoy.when(mock.some_prop).delete().then_raise(RuntimeError("oh no"))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_called_with(self) -> None:
+        """Swap verify function rehearsal with `called_with`."""
+        before = """
+            decoy.verify(some_func("hello", "world"))
+        """
+        after = """
+            decoy.verify(some_func).called_with("hello", "world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_called_with_on_self(self) -> None:
+        """Swap when function rehearsal with `called_with` from `self._decoy`."""
+        before = """
+            self._decoy.verify(some_func("hello", "world"))
+            self.decoy.verify(some_func("hello", "world"))
+        """
+        after = """
+            self._decoy.verify(some_func).called_with("hello", "world")
+            self.decoy.verify(some_func).called_with("hello", "world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_attribute_get(self) -> None:
+        """Swap verify attribute rehearsal with `get`."""
+        before = """
+            decoy.verify(mock.some_prop)
+        """
+        after = """
+            decoy.verify(mock.some_prop).get()
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_called_with_extra_args(self) -> None:
+        """Swap verify function rehearsal with `called_with`, keeping extra args."""
+        before = """
+            decoy.verify(some_func("hello"), times=1)
+        """
+        after = """
+            decoy.verify(some_func, times=1).called_with("hello")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_called_with_ignore_extra_args(self) -> None:
+        """Swap verify function rehearsal with `called_with`, keeping ignore_extra_args."""
+        before = """
+            decoy.verify(some_func("hello"), ignore_extra_args=True)
+        """
+        after = """
+            decoy.verify(some_func, ignore_extra_args=True).called_with("hello")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order(self) -> None:
+        """Swap multiple rehearsals in `verify` for `verify_order`."""
+        before = """
+            decoy.verify(
+                some_func("hello"),
+                other_func("world"),
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func).called_with("hello")
+                decoy.verify(other_func).called_with("world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_on_self(self) -> None:
+        """Swap multiple rehearsals in `verify` for `verify_order` on `self`."""
+        before = """
+            self.decoy.verify(
+                some_func("hello"),
+                other_func("world"),
+            )
+            self._decoy.verify(
+                some_func("hello"),
+                other_func("world"),
+            )
+        """
+        after = """
+            with self.decoy.verify_order():
+                self.decoy.verify(some_func).called_with("hello")
+                self.decoy.verify(other_func).called_with("world")
+            with self._decoy.verify_order():
+                self._decoy.verify(some_func).called_with("hello")
+                self._decoy.verify(other_func).called_with("world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_attributes(self) -> None:
+        """Swaps multiple attribute rehearsals in `verify` for `verify_order`."""
+        before = """
+            decoy.verify(
+                decoy.prop(some.attr).set("hello"),
+                other_func("world"),
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some.attr).set("hello")
+                decoy.verify(other_func).called_with("world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_kwargs(self) -> None:
+        """Copies kwargs to each verify."""
+        before = """
+            decoy.verify(
+                some_func("hello"),
+                other_func("world"),
+                times=1,
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func, times=1).called_with("hello")
+                decoy.verify(other_func, times=1).called_with("world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_spread(self) -> None:
+        """It migrates conditional spreads in a verify order."""
+        before = """
+            decoy.verify(
+                some_func("hello"),
+                *(
+                    some_flag
+                    and [
+                      other_func("world"),
+                      another_func("fizzbuzz"),
+                    ]
+                    or []
+                )
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func).called_with("hello")
+                if some_flag:
+                    decoy.verify(other_func).called_with("world")
+                    decoy.verify(another_func).called_with("fizzbuzz")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_whitespace(self) -> None:
+        """It clears out whitespace and commas."""
+        before = """
+            decoy.when(
+                mock(
+                    some_arg="some-value",
+                )
+            ).then_return("some-result")
+        """
+        after = """
+            decoy.when(mock).called_with(some_arg="some-value").then_return("some-result")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_async(self) -> None:
+        """It migrates async rehearsals."""
+        before = """
+            decoy.when(await mock("hello")).then_return("world")
+            decoy.verify(await mock("hello"))
+        """
+        after = """
+            decoy.when(mock).called_with("hello").then_return("world")
+            decoy.verify(mock).called_with("hello")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_async_verify_order(self) -> None:
+        """Swap multiple async rehearsals in `verify` for `verify_order`."""
+        before = """
+            decoy.verify(
+                await some_func("hello"),
+                await other_func("world"),
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func).called_with("hello")
+                decoy.verify(other_func).called_with("world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_matcher_in_call(self) -> None:
+        """Migrates `matchers` to type-safe `Matcher` in a call."""
+        cases = [
+            (
+                "matchers.AnythingOrNone()",
+                "Matcher.any()",
+            ),
+            (
+                'matchers.HasAttributes({"hello": "world"})',
+                'Matcher.any(attrs={"hello": "world"})',
+            ),
+            (
+                'matchers.HasAttributes(attributes={"hello": "world"})',
+                'Matcher.any(attrs={"hello": "world"})',
+            ),
+            (
+                "matchers.IsA(HelloWorld)",
+                "Matcher.any(HelloWorld)",
+            ),
+            (
+                "matchers.IsA(match_type=HelloWorld)",
+                "Matcher.any(type=HelloWorld)",
+            ),
+            (
+                'matchers.IsA(HelloWorld, {"hello": "world"})',
+                'Matcher.any(HelloWorld, {"hello": "world"})',
+            ),
+            (
+                'matchers.IsA(match_type=HelloWorld, attributes={"hello": "world"})',
+                'Matcher.any(type=HelloWorld, attrs={"hello": "world"})',
+            ),
+            (
+                'matchers.DictMatching({"hello": "world"})',
+                'Matcher.contains({"hello": "world"})',
+            ),
+            (
+                'matchers.ListMatching(["hello", "world"])',
+                'Matcher.contains(["hello", "world"])',
+            ),
+            (
+                "matchers.ErrorMatching(HelloWorldError)",
+                "Matcher.error(HelloWorldError)",
+            ),
+            (
+                "matchers.ErrorMatching(error=HelloWorldError)",
+                "Matcher.error(type=HelloWorldError)",
+            ),
+            (
+                'matchers.ErrorMatching(HelloWorldError, "hello world")',
+                'Matcher.error(HelloWorldError, "hello world")',
+            ),
+            (
+                'matchers.ErrorMatching(error=HelloWorldError, match="hello world")',
+                'Matcher.error(type=HelloWorldError, match="hello world")',
+            ),
+            (
+                'matchers.IsNot("hello world")',
+                'Matcher.is_not("hello world")',
+            ),
+            (
+                "matchers.Anything()",
+                "Matcher.is_not(None)",
+            ),
+            (
+                'matchers.StringMatching("hello world")',
+                'Matcher.matches("hello world")',
+            ),
+        ]
+
+        for before, after in cases:
+            self.assertCodemod(
+                f"""
+                    mock({before})
+                """,
+                f"""
+                    mock({after}.arg)
+                """,
+            )
+
+    def test_migrate_unknown_matcher_in_arg_noop(self) -> None:
+        """It leaves unknown matchers alone inside function args."""
+        before = """
+            mock(matchers.FizzBuzz())
+        """
+        after = """
+            mock(matchers.FizzBuzz())
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_isa_only_attrs_kwarg(self) -> None:
+        """It correctly maps IsA when only attributes kwarg is provided."""
+        self.assertCodemod(
+            """
+                mock(matchers.IsA(attributes={"hello": "world"}))
+            """,
+            """
+                mock(Matcher.any(attrs={"hello": "world"}).arg)
+            """,
+        )
+
+    def test_migrate_isa_kwargs_reversed(self) -> None:
+        """It correctly remaps IsA kwargs regardless of order."""
+        self.assertCodemod(
+            """
+                mock(matchers.IsA(attributes={"hello": "world"}, match_type=HelloWorld))
+            """,
+            """
+                mock(Matcher.any(type=HelloWorld, attrs={"hello": "world"}).arg)
+            """,
+        )
+
+    def test_migrate_error_matching_kwargs_reversed(self) -> None:
+        """It correctly remaps ErrorMatching kwargs regardless of order."""
+        self.assertCodemod(
+            """
+                mock(matchers.ErrorMatching(match="hello world", error=HelloWorldError))
+            """,
+            """
+                mock(Matcher.error(type=HelloWorldError, match="hello world").arg)
+            """,
+        )
+
+    def test_migrate_matcher_with_other_args(self) -> None:
+        """It migrates all args that are matchers."""
+        before = """
+            mock("hello", matchers.AnythingOrNone())
+        """
+        after = """
+            mock("hello", Matcher.any().arg)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_matcher_standalone(self) -> None:
+        """It migrates matchers in standalone usage."""
+        before = """
+            assert "hello" == matchers.AnythingOrNone()
+        """
+        after = """
+            assert "hello" == Matcher.any()
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_matcher_call_in_collection(self) -> None:
+        """It migrates matchers in standalone usage."""
+        before = """
+            mock([matchers.AnythingOrNone()])
+            mock((matchers.AnythingOrNone(),))
+        """
+        after = """
+            mock([Matcher.any().arg])
+            mock((Matcher.any().arg,))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_legacy_captor(self) -> None:
+        """It migrates legacy captor matchers."""
+        before = """
+            def test_one():
+                captor = matchers.Captor()
+                mock("hello", captor)
+
+            def test_two():
+                captor = SomethingElse()
+                mock("hello", captor)
+        """
+        after = """
+            def test_one():
+                captor = Matcher.any()
+                mock("hello", captor.arg)
+
+            def test_two():
+                captor = SomethingElse()
+                mock("hello", captor)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_value_captor(self) -> None:
+        """It migrates newer, type-safe `ValueCaptor` matcher."""
+        before = """
+            def test_one():
+                captor = matchers.ValueCaptor()
+                mock("hello", captor.matcher)
+
+            def test_two():
+                captor = SomethingElse()
+                mock("hello", captor)
+        """
+        after = """
+            def test_one():
+                captor = Matcher.any()
+                mock("hello", captor.arg)
+
+            def test_two():
+                captor = SomethingElse()
+                mock("hello", captor)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_spread_async(self) -> None:
+        """It migrates async calls in conditional spreads."""
+        before = """
+            decoy.verify(
+                some_func("hello"),
+                *(
+                    some_flag
+                    and [
+                      await other_func("world"),
+                    ]
+                    or []
+                )
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func).called_with("hello")
+                if some_flag:
+                    decoy.verify(other_func).called_with("world")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_attribute_get(self) -> None:
+        """It migrates bare attribute rehearsals inside verify_order."""
+        before = """
+            decoy.verify(
+                mock.some_prop,
+                other_func("hello"),
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(mock.some_prop).get()
+                decoy.verify(other_func).called_with("hello")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_spread_attribute_get(self) -> None:
+        """It migrates attribute rehearsals inside conditional spreads."""
+        before = """
+            decoy.verify(
+                some_func("hello"),
+                *(some_flag and [mock.some_prop] or [])
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func).called_with("hello")
+                if some_flag:
+                    decoy.verify(mock.some_prop).get()
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_verify_order_spread_nonempty_fallback(self) -> None:
+        """It migrates conditional spreads with a non-empty fallback list."""
+        before = """
+            decoy.verify(
+                some_func("hello"),
+                *(
+                    some_flag
+                    and [other_func("world")]
+                    or [fallback_func("fizzbuzz")]
+                )
+            )
+        """
+        after = """
+            with decoy.verify_order():
+                decoy.verify(some_func).called_with("hello")
+                if some_flag:
+                    decoy.verify(other_func).called_with("world")
+                else:
+                    decoy.verify(fallback_func).called_with("fizzbuzz")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_captor_non_name_target(self) -> None:
+        """It skips captor tracking for non-name assignment targets."""
+        before = """
+            self.captor = matchers.Captor()
+            mock("hello", self.captor)
+        """
+        after = """
+            self.captor = Matcher.any()
+            mock("hello", self.captor)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_captor_multiple_assignments_in_scope(self) -> None:
+        """It identifies a captor among multiple assignments in scope."""
+        before = """
+            def test_one():
+                other_var = 42
+                captor = matchers.Captor()
+                mock("hello", captor)
+        """
+        after = """
+            def test_one():
+                other_var = 42
+                captor = Matcher.any()
+                mock("hello", captor.arg)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_migrate_unknown_matcher_noop(self) -> None:
+        """It leaves unknown matchers alone."""
+        before = """
+            assert "hello" == matchers.FizzBuzz()
+        """
+        after = """
+            assert "hello" == matchers.FizzBuzz()
+        """
+
+        self.assertCodemod(before, after)

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.7"
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
     "python_full_version < '3.8'",
@@ -25,7 +27,9 @@ name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
@@ -373,7 +377,9 @@ name = "coverage"
 version = "7.9.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/e0/98670a80884f64578f0c22cd70c5e81a6e07b08167721c7487b4d70a7ca0/coverage-7.9.1.tar.gz", hash = "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec", size = 813650, upload-time = "2025-06-13T13:02:28.627Z" }
@@ -468,7 +474,9 @@ name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
 ]
@@ -490,6 +498,9 @@ dev = [
     { name = "coverage", version = "7.2.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.8'" },
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version == '3.8.*'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.9'" },
+    { name = "libcst", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "libcst", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+    { name = "libcst", version = "1.8.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "mkdocs", marker = "python_full_version >= '3.10'" },
     { name = "mkdocs-material", marker = "python_full_version >= '3.10'" },
     { name = "mkdocstrings", extra = ["python"], marker = "python_full_version >= '3.10'" },
@@ -519,6 +530,7 @@ dev = [
     { name = "coverage", extras = ["toml"], marker = "python_full_version < '3.8'", specifier = "==7.2.7" },
     { name = "coverage", extras = ["toml"], marker = "python_full_version == '3.8.*'", specifier = "==7.6.1" },
     { name = "coverage", extras = ["toml"], marker = "python_full_version >= '3.9'", specifier = "==7.9.1" },
+    { name = "libcst", specifier = ">=1.0.1" },
     { name = "mkdocs", marker = "python_full_version >= '3.10'", specifier = "==1.6.1" },
     { name = "mkdocs-material", marker = "python_full_version >= '3.10'", specifier = "==9.7.1" },
     { name = "mkdocstrings", extras = ["python"], marker = "python_full_version >= '3.10'", specifier = "==1.0.0" },
@@ -571,7 +583,9 @@ name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
 ]
@@ -668,7 +682,9 @@ name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
@@ -713,7 +729,9 @@ name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -750,7 +768,9 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -760,6 +780,180 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.8'",
+]
+dependencies = [
+    { name = "pyyaml", version = "6.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "typing-inspect", marker = "python_full_version < '3.8'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b2/dd6fcf70dc59281e6de7c4b2f6150d07c26db127262dd5cba16fde1464ed/libcst-1.0.1.tar.gz", hash = "sha256:37187337f979ba426d8bfefc08008c3c1b09b9e9f9387050804ed2da88107570", size = 749520, upload-time = "2023-06-07T12:53:56.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/90/ea0b513c830c487dd4ec581424c544ac0366cb5b7b0045e2bd95796b7bb7/libcst-1.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80423311f09fc5fc3270ede44d30d9d8d3c2d3dd50dbf703a581ca7346949fa6", size = 1863702, upload-time = "2023-06-07T12:52:47.834Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9e/1158d6033a744593a7af39362cbc961036d439b6c49814cfe6e78b7ad2e2/libcst-1.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9d6dec2a3c443792e6af7c36fadc256e4ea586214c76b52f0d18118811dbe351", size = 1821595, upload-time = "2023-06-07T12:52:51.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5c/2a0871654ae1bd9ee2e57bc5d3e2546ef1230a6d7f88adb1f72ccac8b28e/libcst-1.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4840a3de701778f0a19582bb3085c61591329153f801dc25da84689a3733960b", size = 2811339, upload-time = "2023-06-07T12:52:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/23/0cc3da3a7a5989bb34a491c6d51b25aecfba9a8e23efde92f1a15fc20915/libcst-1.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0138068baf09561268c7f079373bda45f0e2b606d2d19df1307ca8a5134fc465", size = 2855430, upload-time = "2023-06-07T12:52:56.512Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e6/5dcaaf8d3c02ced4f496e9eebddb8220056c06b290330ad5a12590fb44f8/libcst-1.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a4931feceab171e6fce73de94e13880424367247dad6ff2b49cabfec733e144", size = 2934193, upload-time = "2023-06-07T12:52:59.114Z" },
+    { url = "https://files.pythonhosted.org/packages/79/61/dbb644542cf4f50ec7e6e1ec10f23d732ecc9835f4e8ab13308c1509e1e5/libcst-1.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:47dba43855e9c7b06d8b256ee81f0ebec6a4f43605456519577e09dfe4b4288c", size = 1812922, upload-time = "2023-06-07T12:53:01.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/af4efe8864edfb9dd22486ef9cdc3cea5b4a0030b8b75d7792acd6bf67a0/libcst-1.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c50541c3fd6b1d5a3765c4bb5ee8ecbba9d0e798e48f79fd5adf3b6752de4d0", size = 1863701, upload-time = "2023-06-07T12:53:03.609Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c1/2f633311d479e8fcbfdfd7bc5e22ce1c2b94dd1734238c197024c08c1d23/libcst-1.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5599166d5fec40e18601fb8868519dde99f77b6e4ad6074958018f9545da7abd", size = 1821596, upload-time = "2023-06-07T12:53:05.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ed/b81f0613bf23f49d6a0a8f9370d5badfad5bb46fb429e1d4b82c8812e100/libcst-1.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:600c4d3a9a2f75d5a055fed713a5a4d812709947909610aa6527abe08a31896f", size = 2811321, upload-time = "2023-06-07T12:53:07.799Z" },
+    { url = "https://files.pythonhosted.org/packages/68/14/c6708490dd74cc833e62731725024cc27d1fed38cf1cd03217bb35a88a37/libcst-1.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6b5aea04c35e13109edad3cf83bc6dcd74309b150a781d2189eecb288b73a87", size = 2855424, upload-time = "2023-06-07T12:53:10.626Z" },
+    { url = "https://files.pythonhosted.org/packages/51/19/763eefa2d39f25ac4c9988387d5607fd8f3ed5e929af9f10eb30c712a306/libcst-1.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ddd4e0eeec499d1c824ab545e62e957dbbd69a16bc4273208817638eb7d6b3c6", size = 2934192, upload-time = "2023-06-07T12:53:12.707Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/72/6c99471219c4e9a40c07909f5baed3eccfeab4a2063c54d1fc0ccfe9b1fc/libcst-1.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:414350df5e334ddf0db1732d63da44e81b734d45abe1c597b5e5c0dd46aa4156", size = 1812928, upload-time = "2023-06-07T12:53:14.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bb/1609e940be017480680eb5cc2e0fcb0971c1a3821b51804c8b14928182d5/libcst-1.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1adcfa7cafb6a0d39a1a0bec541355608038b45815e0c5019c95f91921d42884", size = 1863145, upload-time = "2023-06-07T12:53:16.816Z" },
+    { url = "https://files.pythonhosted.org/packages/38/00/a11a447fb6d48c6f69822fe2fc55b011a7b6ddd4cbd8a718442ac382dbc5/libcst-1.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d31ce2790eab59c1bd8e33fe72d09cfc78635c145bdc3f08296b360abb5f443", size = 2808373, upload-time = "2023-06-07T12:53:18.619Z" },
+    { url = "https://files.pythonhosted.org/packages/01/29/554357cbbd9c894c58241f0403cbab9c6c1842eb6eb7ebc6d30a2fedaefa/libcst-1.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2cb687e1514625e91024e50a5d2e485c0ad3be24f199874ebf32b5de0346150", size = 2851967, upload-time = "2023-06-07T12:53:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4d/602abfcdc97d1c3da768f31ef5d9e2f27db62676356b64a98205498313a0/libcst-1.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6caa33430c0c7a0fcad921b0deeec61ddb96796b6f88dca94966f6db62065f4f", size = 2930835, upload-time = "2023-06-07T12:53:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/00/6a/47b61d3c9f6d8f382ead9f068131d3ab742540bc2307292b69f896fa3f78/libcst-1.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:b97f652b15c50e91df411a9c8d5e6f75882b30743a49b387dcedd3f68ed94d75", size = 1812716, upload-time = "2023-06-07T12:53:25.526Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/be/01ee6bcc9452094638ebf6f4f975e7dfaff050c9d8623757b0700201aa10/libcst-1.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:967c66fabd52102954207bf1541312b467afc210fdf7033f32da992fb6c2372c", size = 1863228, upload-time = "2023-06-07T12:53:28.314Z" },
+    { url = "https://files.pythonhosted.org/packages/32/10/f3da8077892a1691f73723ea4e7598fd20eb7a752aad780c04fe0719a374/libcst-1.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b666a605f4205c8357696f3b6571a38f6a8537cdcbb8f357587d35168298af34", size = 1821539, upload-time = "2023-06-07T12:53:30.873Z" },
+    { url = "https://files.pythonhosted.org/packages/29/34/93e180facfa6abf19843d6e38ae468db8ea93decbe889335472bc959420b/libcst-1.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae49dcbfadefb82e830d41d9f0a1db0af3b771224768f431f1b7b3a9803ed7e3", size = 2808338, upload-time = "2023-06-07T12:53:32.869Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bc/1112e0707566230709965817f2881fc18f9a322bbbb52ae8adf7c28981cc/libcst-1.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c90c74a8a314f0774f045122323fb60bacba79cbf5f71883c0848ecd67179541", size = 2852015, upload-time = "2023-06-07T12:53:35.195Z" },
+    { url = "https://files.pythonhosted.org/packages/68/41/9824b7a575e96eb2525f192541c4413044ea8500c651ae398353285861cf/libcst-1.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0533de4e35396c61aeb3a6266ac30369a855910c2385aaa902ff4aabd60d409", size = 2930670, upload-time = "2023-06-07T12:53:37.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/5d/efa25625ae5da55aeca0ef49519278b6a33feb40d9094bca41e20e87d780/libcst-1.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:5e3293e77657ba62533553bb9f0c5fb173780e164c65db1ea2a3e0d03944a284", size = 1812706, upload-time = "2023-06-07T12:53:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/51/3dc19576d1b1a53dc59cbe78586a6996eb5e96cd7a3a228dc544505af0e5/libcst-1.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:119ba709f1dcb785a4458cf36cedb51d6f9cb2eec0acd7bb171f730eac7cb6ce", size = 1863697, upload-time = "2023-06-07T12:53:42.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/df/9c7af7d8756d436ceb3c5046a93781141b2ee2c54d2c09d4096b1bbad4a6/libcst-1.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b4e336f6d68456017671cdda8ddebf9caebce8052cc21a3f494b03d7bd28386", size = 1821586, upload-time = "2023-06-07T12:53:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/28/31/57f77e87eef8ada6724e65d6838d599a10b3f9cbe991b310af83d387f14c/libcst-1.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8420926791b0b6206cb831a7ec73d26ae820e65bdf07ce9813c7754c7722c07a", size = 2811360, upload-time = "2023-06-07T12:53:47.336Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3a/90caf552575489412bc4b041ca9894062ca2f0200cd7df8884325f0575bf/libcst-1.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d237e9164a43caa7d6765ee560412264484e7620c546a2ee10a8d01bd56884e0", size = 2855399, upload-time = "2023-06-07T12:53:49.557Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f7/ab8ea8608b63e4c1790af89e8ccb419356788aba2f9f8a1ef084be342a10/libcst-1.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:440887e5f82efb299f2e98d4bfa5663851a878cfc0efed652ab8c50205191436", size = 2934212, upload-time = "2023-06-07T12:53:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f6/98c32c80b5fec10a39b6cb74bbf9363d627c60535b96f9d3c15848515109/libcst-1.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:ae7f4e71d714f256b5f2ff98b5a9effba0f9dff4d779d8f35d7eb157bef78f59", size = 1812915, upload-time = "2023-06-07T12:53:54.207Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.8.*'",
+]
+dependencies = [
+    { name = "pyyaml", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+    { name = "typing-inspect", marker = "python_full_version == '3.8.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/ef/610498b5e982d9dd64f2af8422ece1be44a946a8dbda15d08087e0e1ff08/libcst-1.1.0.tar.gz", hash = "sha256:0acbacb9a170455701845b7e940e2d7b9519db35a86768d86330a0b0deae1086", size = 764691, upload-time = "2023-10-06T02:50:16.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/bdd31ed5c8ad1978aa5d0350e64769ea91c7710a4d34e159c696e6c145e7/libcst-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:63f75656fd733dc20354c46253fde3cf155613e37643c3eaf6f8818e95b7a3d1", size = 2112700, upload-time = "2023-10-06T02:49:15.356Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/27/889bc60abece5f5c998560c9d61898e548a48e6a72c75490582cde878e8d/libcst-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ae11eb1ea55a16dc0cdc61b41b29ac347da70fec14cc4381248e141ee2fbe6c", size = 2070222, upload-time = "2023-10-06T02:49:17.895Z" },
+    { url = "https://files.pythonhosted.org/packages/20/23/d5b4e03fdec2275bd2f96b19a1317fed736f68411dfa6913e206888930ed/libcst-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bc745d0c06420fe2644c28d6ddccea9474fb68a2135904043676deb4fa1e6bc", size = 3154843, upload-time = "2023-10-06T02:49:20.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0d/723754c5a50fd57a3fddc17960e98f809a46a898419a39a5da5795ca6983/libcst-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c1f2da45f1c45634090fd8672c15e0159fdc46853336686959b2d093b6e10fa", size = 3194222, upload-time = "2023-10-06T02:49:22.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d8/9d598a272f2d7687f1936836bd67bf8b13623fbf43210e8745157732a87e/libcst-1.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:003e5e83a12eed23542c4ea20fdc8de830887cc03662432bb36f84f8c4841b81", size = 3300452, upload-time = "2023-10-06T02:49:24.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/41/bed99411d679318116673bbd7d96f65ccf382770898719109f5927250b74/libcst-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:3ebbb9732ae3cc4ae7a0e97890bed0a57c11d6df28790c2b9c869f7da653c7c7", size = 2031202, upload-time = "2023-10-06T02:49:27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/01/20eef81a259a7555def181917ac21180b0ccd694b62851d251c69e55b431/libcst-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d68c34e3038d3d1d6324eb47744cbf13f2c65e1214cf49db6ff2a6603c1cd838", size = 2112699, upload-time = "2023-10-06T02:49:29.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e3/f9b7528ebd96e5b507c401830f81274806fe7f76e65668dee9884fdb8465/libcst-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9dffa1795c2804d183efb01c0f1efd20a7831db6a21a0311edf90b4100d67436", size = 2070226, upload-time = "2023-10-06T02:49:30.554Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/88/1a0dd13408be61a5fcd83ecf0ee85c2b4795dab7d3c5544a8ae35f495265/libcst-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc9b6ac36d7ec9db2f053014ea488086ca2ed9c322be104fbe2c71ca759da4bb", size = 3154844, upload-time = "2023-10-06T02:49:32.381Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a6/3414494d9767eb937d2261f070d5edf12dac26cbf8df0f4a9619a119e033/libcst-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b7a38ec4c1c009ac39027d51558b52851fb9234669ba5ba62283185963a31c", size = 3194221, upload-time = "2023-10-06T02:49:34.545Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a6/3085ab81c6effe43590827cd4748d44621cd94ef6bf9f70a301985e4b566/libcst-1.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5297a16e575be8173185e936b7765c89a3ca69d4ae217a4af161814a0f9745a7", size = 3300454, upload-time = "2023-10-06T02:49:36.396Z" },
+    { url = "https://files.pythonhosted.org/packages/01/3b/9f1b0f4401e439bbf42162468c3583799fa80fa441b47ef103f79d0fd61a/libcst-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:7ccaf53925f81118aeaadb068a911fac8abaff608817d7343da280616a5ca9c1", size = 2031205, upload-time = "2023-10-06T02:49:38.745Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bd/0143bc80fee8544d4c3bf7a4ba098b8a86d7a08df2c8cbce1e04300c5f47/libcst-1.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:75816647736f7e09c6120bdbf408456f99b248d6272277eed9a58cf50fb8bc7d", size = 2112700, upload-time = "2023-10-06T02:49:40.969Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b8/d144476de088d6b2ed40b7c6a02f89df91f0163cab1315ff5944bf1796a6/libcst-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8f26250f87ca849a7303ed7a4fd6b2c7ac4dec16b7d7e68ca6a476d7c9bfcdb", size = 2070223, upload-time = "2023-10-06T02:49:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/98/a30992fa79669e10cf0f7ae8749d460f713f968c66cd48c569c6ed87f705/libcst-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d37326bd6f379c64190a28947a586b949de3a76be00176b0732c8ee87d67ebe", size = 3155322, upload-time = "2023-10-06T02:49:44.947Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2a2af5d477ea98af05534f76260647da308d20c0cdd10bc05107d2755b0f/libcst-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3d8cf974cfa2487b28f23f56c4bff90d550ef16505e58b0dca0493d5293784b", size = 3194986, upload-time = "2023-10-06T02:49:47.335Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/76/c2867a61f185c1a21cf5e10c8020b763250f5523a042535c609215800389/libcst-1.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82d1271403509b0a4ee6ff7917c2d33b5a015f44d1e208abb1da06ba93b2a378", size = 3300603, upload-time = "2023-10-06T02:49:49.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/1504eb1d4c2cf7f251e1c719734d6f1560dd5532c25871983ef36d9cab03/libcst-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bca1841693941fdd18371824bb19a9702d5784cd347cb8231317dbdc7062c5bc", size = 2031201, upload-time = "2023-10-06T02:49:51.259Z" },
+    { url = "https://files.pythonhosted.org/packages/df/76/ef29f8f26e9ca89a75c138b1cc4de936bc648607c2fe4e2ee2201201a1b0/libcst-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f36f592e035ef84f312a12b75989dde6a5f6767fe99146cdae6a9ee9aff40dd0", size = 2112679, upload-time = "2023-10-06T02:49:53.05Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/29/4cf0e0bdc5c9045ba13c1ef86e75af6db1d55e67b798c9d7f0d2631ff85a/libcst-1.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f561c9a84eca18be92f4ad90aa9bd873111efbea995449301719a1a7805dbc5c", size = 2070261, upload-time = "2023-10-06T02:49:54.707Z" },
+    { url = "https://files.pythonhosted.org/packages/df/72/b1a969b0a7f9184f1a7181b30a09d88479aaf9af861bae10d7207780aa88/libcst-1.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97fbc73c87e9040e148881041fd5ffa2a6ebf11f64b4ccb5b52e574b95df1a15", size = 3154652, upload-time = "2023-10-06T02:49:56.268Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9f/9b4278b8e6e2cfd56caab73e69388fc6da1aa42961cbc777a45888db8e11/libcst-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99fdc1929703fd9e7408aed2e03f58701c5280b05c8911753a8d8619f7dfdda5", size = 3194182, upload-time = "2023-10-06T02:49:58.185Z" },
+    { url = "https://files.pythonhosted.org/packages/be/fa/7b8abb0c5e6f30953dd82fba70cbf9c36d3832fc36d329cb408241ac25c2/libcst-1.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bf69cbbab5016d938aac4d3ae70ba9ccb3f90363c588b3b97be434e6ba95403", size = 3300688, upload-time = "2023-10-06T02:49:59.979Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/13e5a9f9831aebffced7f42e8304ce9f09ca85f7f713b21d22fb7b571140/libcst-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:fe41b33aa73635b1651f64633f429f7aa21f86d2db5748659a99d9b7b1ed2a90", size = 2031062, upload-time = "2023-10-06T02:50:01.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4f/e989c0b07749143f3608814f712bc27ad48a72f5ba890c4bea7df4258c23/libcst-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:73c086705ed34dbad16c62c9adca4249a556c1b022993d511da70ea85feaf669", size = 2112658, upload-time = "2023-10-06T02:50:03.716Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/c3/c7e56011c477df755d78ee734dd1caa5e6ff6cc51a07071adbc452df998f/libcst-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3a07ecfabbbb8b93209f952a365549e65e658831e9231649f4f4e4263cad24b1", size = 2070233, upload-time = "2023-10-06T02:50:06.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f3/49bdd4be2a9a89834e89adf3c0377c1c6387e00634efa0d0c078a49ee034/libcst-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c653d9121d6572d8b7f8abf20f88b0a41aab77ff5a6a36e5a0ec0f19af0072e8", size = 3155034, upload-time = "2023-10-06T02:50:08.079Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d2/544d481b33dbc35381d976221ab1358fab0db4588c2d53214500454e9fd5/libcst-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f1cd308a4c2f71d5e4eec6ee693819933a03b78edb2e4cc5e3ad1afd5fb3f07", size = 3194521, upload-time = "2023-10-06T02:50:09.873Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1c/c2d4e2b6a69fc8fd52ae6c0662dfa4550486712d5e77cf754348e4c85a2c/libcst-1.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8afb6101b8b3c86c5f9cec6b90ab4da16c3c236fe7396f88e8b93542bb341f7c", size = 3300712, upload-time = "2023-10-06T02:50:11.892Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/76/b31dba704487daf0845fc2d246ddb1a141a1dd12ef695d30eb4b0aac51c5/libcst-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:d22d1abfe49aa60fc61fa867e10875a9b3024ba5a801112f4d7ba42d8d53242e", size = 2031198, upload-time = "2023-10-06T02:50:14.431Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.8.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "pyyaml", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version >= '3.9' and python_full_version < '3.13')" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cd/337df968b38d94c5aabd3e1b10630f047a2b345f6e1d4456bd9fe7417537/libcst-1.8.6.tar.gz", hash = "sha256:f729c37c9317126da9475bdd06a7208eb52fcbd180a6341648b45a56b4ba708b", size = 891354, upload-time = "2025-11-03T22:33:30.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/52/97d5454dee9d014821fe0c88f3dc0e83131b97dd074a4d49537056a75475/libcst-1.8.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a20c5182af04332cc94d8520792befda06d73daf2865e6dddc5161c72ea92cb9", size = 2211698, upload-time = "2025-11-03T22:31:50.117Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a4/d1205985d378164687af3247a9c8f8bdb96278b0686ac98ab951bc6d336a/libcst-1.8.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:36473e47cb199b7e6531d653ee6ffed057de1d179301e6c67f651f3af0b499d6", size = 2093104, upload-time = "2025-11-03T22:31:52.189Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/de/1338da681b7625b51e584922576d54f1b8db8fc7ff4dc79121afc5d4d2cd/libcst-1.8.6-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:06fc56335a45d61b7c1b856bfab4587b84cfe31e9d6368f60bb3c9129d900f58", size = 2237419, upload-time = "2025-11-03T22:31:53.526Z" },
+    { url = "https://files.pythonhosted.org/packages/50/06/ee66f2d83b870534756e593d464d8b33b0914c224dff3a407e0f74dc04e0/libcst-1.8.6-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6b23d14a7fc0addd9795795763af26b185deb7c456b1e7cc4d5228e69dab5ce8", size = 2300820, upload-time = "2025-11-03T22:31:55.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ca/959088729de8e0eac8dd516e4fb8623d8d92bad539060fa85c9e94d418a5/libcst-1.8.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:16cfe0cfca5fd840e1fb2c30afb628b023d3085b30c3484a79b61eae9d6fe7ba", size = 2301201, upload-time = "2025-11-03T22:31:57.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/2a21a8c452436097dfe1da277f738c3517f3f728713f16d84b9a3d67ca8d/libcst-1.8.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:455f49a93aea4070132c30ebb6c07c2dea0ba6c1fde5ffde59fc45dbb9cfbe4b", size = 2408213, upload-time = "2025-11-03T22:31:59.221Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/26/8f7b671fad38a515bb20b038718fd2221ab658299119ac9bcec56c2ced27/libcst-1.8.6-cp310-cp310-win_amd64.whl", hash = "sha256:72cca15800ffc00ba25788e4626189fe0bc5fe2a0c1cb4294bce2e4df21cc073", size = 2119189, upload-time = "2025-11-03T22:32:00.696Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bf/ffb23a48e27001165cc5c81c5d9b3d6583b21b7f5449109e03a0020b060c/libcst-1.8.6-cp310-cp310-win_arm64.whl", hash = "sha256:6cad63e3a26556b020b634d25a8703b605c0e0b491426b3e6b9e12ed20f09100", size = 2001736, upload-time = "2025-11-03T22:32:02.986Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/15/95c2ecadc0fb4af8a7057ac2012a4c0ad5921b9ef1ace6c20006b56d3b5f/libcst-1.8.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3649a813660fbffd7bc24d3f810b1f75ac98bd40d9d6f56d1f0ee38579021073", size = 2211289, upload-time = "2025-11-03T22:32:04.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c3/7e1107acd5ed15cf60cc07c7bb64498a33042dc4821874aea3ec4942f3cd/libcst-1.8.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cbe17067055829607c5ba4afa46bfa4d0dd554c0b5a583546e690b7367a29b6", size = 2092927, upload-time = "2025-11-03T22:32:06.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ff/0d2be87f67e2841a4a37d35505e74b65991d30693295c46fc0380ace0454/libcst-1.8.6-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:59a7e388c57d21d63722018978a8ddba7b176e3a99bd34b9b84a576ed53f2978", size = 2237002, upload-time = "2025-11-03T22:32:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/8c4a1b35c7894ccd7d33eae01ac8967122f43da41325223181ca7e4738fe/libcst-1.8.6-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b6c1248cc62952a3a005792b10cdef2a4e130847be9c74f33a7d617486f7e532", size = 2301048, upload-time = "2025-11-03T22:32:08.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8b/d1aa811eacf936cccfb386ae0585aa530ea1221ccf528d67144e041f5915/libcst-1.8.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6421a930b028c5ef4a943b32a5a78b7f1bf15138214525a2088f11acbb7d3d64", size = 2300675, upload-time = "2025-11-03T22:32:10.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6b/7b65cd41f25a10c1fef2389ddc5c2b2cc23dc4d648083fa3e1aa7e0eeac2/libcst-1.8.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6d8b67874f2188399a71a71731e1ba2d1a2c3173b7565d1cc7ffb32e8fbaba5b", size = 2407934, upload-time = "2025-11-03T22:32:11.856Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/401cfff374bb3b785adfad78f05225225767ee190997176b2a9da9ed9460/libcst-1.8.6-cp311-cp311-win_amd64.whl", hash = "sha256:b0d8c364c44ae343937f474b2e492c1040df96d94530377c2f9263fb77096e4f", size = 2119247, upload-time = "2025-11-03T22:32:13.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/085f59eaa044b6ff6bc42148a5449df2b7f0ba567307de7782fe85c39ee2/libcst-1.8.6-cp311-cp311-win_arm64.whl", hash = "sha256:5dcaaebc835dfe5755bc85f9b186fb7e2895dda78e805e577fef1011d51d5a5c", size = 2001774, upload-time = "2025-11-03T22:32:14.647Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3c/93365c17da3d42b055a8edb0e1e99f1c60c776471db6c9b7f1ddf6a44b28/libcst-1.8.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0c13d5bd3d8414a129e9dccaf0e5785108a4441e9b266e1e5e9d1f82d1b943c9", size = 2206166, upload-time = "2025-11-03T22:32:16.012Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cb/7530940e6ac50c6dd6022349721074e19309eb6aa296e942ede2213c1a19/libcst-1.8.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1472eeafd67cdb22544e59cf3bfc25d23dc94058a68cf41f6654ff4fcb92e09", size = 2083726, upload-time = "2025-11-03T22:32:17.312Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/cf/7e5eaa8c8f2c54913160671575351d129170db757bb5e4b7faffed022271/libcst-1.8.6-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:089c58e75cb142ec33738a1a4ea7760a28b40c078ab2fd26b270dac7d2633a4d", size = 2235755, upload-time = "2025-11-03T22:32:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/55/54/570ec2b0e9a3de0af9922e3bb1b69a5429beefbc753a7ea770a27ad308bd/libcst-1.8.6-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c9d7aeafb1b07d25a964b148c0dda9451efb47bbbf67756e16eeae65004b0eb5", size = 2301473, upload-time = "2025-11-03T22:32:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4c/163457d1717cd12181c421a4cca493454bcabd143fc7e53313bc6a4ad82a/libcst-1.8.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207481197afd328aa91d02670c15b48d0256e676ce1ad4bafb6dc2b593cc58f1", size = 2298899, upload-time = "2025-11-03T22:32:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1d/317ddef3669883619ef3d3395ea583305f353ef4ad87d7a5ac1c39be38e3/libcst-1.8.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:375965f34cc6f09f5f809244d3ff9bd4f6cb6699f571121cebce53622e7e0b86", size = 2408239, upload-time = "2025-11-03T22:32:23.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a1/f47d8cccf74e212dd6044b9d6dbc223636508da99acff1d54786653196bc/libcst-1.8.6-cp312-cp312-win_amd64.whl", hash = "sha256:da95b38693b989eaa8d32e452e8261cfa77fe5babfef1d8d2ac25af8c4aa7e6d", size = 2119660, upload-time = "2025-11-03T22:32:24.822Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d0/dd313bf6a7942cdf951828f07ecc1a7695263f385065edc75ef3016a3cb5/libcst-1.8.6-cp312-cp312-win_arm64.whl", hash = "sha256:bff00e1c766658adbd09a175267f8b2f7616e5ee70ce45db3d7c4ce6d9f6bec7", size = 1999824, upload-time = "2025-11-03T22:32:26.131Z" },
+    { url = "https://files.pythonhosted.org/packages/90/01/723cd467ec267e712480c772aacc5aa73f82370c9665162fd12c41b0065b/libcst-1.8.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7445479ebe7d1aff0ee094ab5a1c7718e1ad78d33e3241e1a1ec65dcdbc22ffb", size = 2206386, upload-time = "2025-11-03T22:32:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/b944944f910f24c094f9b083f76f61e3985af5a376f5342a21e01e2d1a81/libcst-1.8.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fc3fef8a2c983e7abf5d633e1884c5dd6fa0dcb8f6e32035abd3d3803a3a196", size = 2083945, upload-time = "2025-11-03T22:32:28.847Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/bd1b2b2b7f153d82301cdaddba787f4a9fc781816df6bdb295ca5f88b7cf/libcst-1.8.6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1a3a5e4ee870907aa85a4076c914ae69066715a2741b821d9bf16f9579de1105", size = 2235818, upload-time = "2025-11-03T22:32:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ab/f5433988acc3b4d188c4bb154e57837df9488cc9ab551267cdeabd3bb5e7/libcst-1.8.6-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6609291c41f7ad0bac570bfca5af8fea1f4a27987d30a1fa8b67fe5e67e6c78d", size = 2301289, upload-time = "2025-11-03T22:32:31.812Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/57/89f4ba7a6f1ac274eec9903a9e9174890d2198266eee8c00bc27eb45ecf7/libcst-1.8.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25eaeae6567091443b5374b4c7d33a33636a2d58f5eda02135e96fc6c8807786", size = 2299230, upload-time = "2025-11-03T22:32:33.242Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/0aa693bc24cce163a942df49d36bf47a7ed614a0cd5598eee2623bc31913/libcst-1.8.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04030ea4d39d69a65873b1d4d877def1c3951a7ada1824242539e399b8763d30", size = 2408519, upload-time = "2025-11-03T22:32:34.678Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/6dd055b5f15afa640fb3304b2ee9df8b7f72e79513814dbd0a78638f4a0e/libcst-1.8.6-cp313-cp313-win_amd64.whl", hash = "sha256:8066f1b70f21a2961e96bedf48649f27dfd5ea68be5cd1bed3742b047f14acde", size = 2119853, upload-time = "2025-11-03T22:32:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ed/5ddb2a22f0b0abdd6dcffa40621ada1feaf252a15e5b2733a0a85dfd0429/libcst-1.8.6-cp313-cp313-win_arm64.whl", hash = "sha256:c188d06b583900e662cd791a3f962a8c96d3dfc9b36ea315be39e0a4c4792ebf", size = 1999808, upload-time = "2025-11-03T22:32:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d3/72b2de2c40b97e1ef4a1a1db4e5e52163fc7e7740ffef3846d30bc0096b5/libcst-1.8.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c41c76e034a1094afed7057023b1d8967f968782433f7299cd170eaa01ec033e", size = 2190553, upload-time = "2025-11-03T22:32:39.819Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/983b7b210ccc3ad94a82db54230e92599c4a11b9cfc7ce3bc97c1d2df75c/libcst-1.8.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5432e785322aba3170352f6e72b32bea58d28abd141ac37cc9b0bf6b7c778f58", size = 2074717, upload-time = "2025-11-03T22:32:41.373Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f2/9e01678fedc772e09672ed99930de7355757035780d65d59266fcee212b8/libcst-1.8.6-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:85b7025795b796dea5284d290ff69de5089fc8e989b25d6f6f15b6800be7167f", size = 2225834, upload-time = "2025-11-03T22:32:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0d/7bed847b5c8c365e9f1953da274edc87577042bee5a5af21fba63276e756/libcst-1.8.6-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:536567441182a62fb706e7aa954aca034827b19746832205953b2c725d254a93", size = 2287107, upload-time = "2025-11-03T22:32:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f0/7e51fa84ade26c518bfbe7e2e4758b56d86a114c72d60309ac0d350426c4/libcst-1.8.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f04d3672bde1704f383a19e8f8331521abdbc1ed13abb349325a02ac56e5012", size = 2288672, upload-time = "2025-11-03T22:32:45.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/15762659a3f5799d36aab1bc2b7e732672722e249d7800e3c5f943b41250/libcst-1.8.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f04febcd70e1e67917be7de513c8d4749d2e09206798558d7fe632134426ea4", size = 2392661, upload-time = "2025-11-03T22:32:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6b/b7f9246c323910fcbe021241500f82e357521495dcfe419004dbb272c7cb/libcst-1.8.6-cp313-cp313t-win_amd64.whl", hash = "sha256:1dc3b897c8b0f7323412da3f4ad12b16b909150efc42238e19cbf19b561cc330", size = 2105068, upload-time = "2025-11-03T22:32:49.145Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0b/4fd40607bc4807ec2b93b054594373d7fa3d31bb983789901afcb9bcebe9/libcst-1.8.6-cp313-cp313t-win_arm64.whl", hash = "sha256:44f38139fa95e488db0f8976f9c7ca39a64d6bc09f2eceef260aa1f6da6a2e42", size = 1985181, upload-time = "2025-11-03T22:32:50.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/60/4105441989e321f7ad0fd28ffccb83eb6aac0b7cfb0366dab855dcccfbe5/libcst-1.8.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:b188e626ce61de5ad1f95161b8557beb39253de4ec74fc9b1f25593324a0279c", size = 2204202, upload-time = "2025-11-03T22:32:52.311Z" },
+    { url = "https://files.pythonhosted.org/packages/67/2f/51a6f285c3a183e50cfe5269d4a533c21625aac2c8de5cdf2d41f079320d/libcst-1.8.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:87e74f7d7dfcba9efa91127081e22331d7c42515f0a0ac6e81d4cf2c3ed14661", size = 2083581, upload-time = "2025-11-03T22:32:54.269Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/921b1c19b638860af76cdb28bc81d430056592910b9478eea49e31a7f47a/libcst-1.8.6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3a926a4b42015ee24ddfc8ae940c97bd99483d286b315b3ce82f3bafd9f53474", size = 2236495, upload-time = "2025-11-03T22:32:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a8/b00592f9bede618cbb3df6ffe802fc65f1d1c03d48a10d353b108057d09c/libcst-1.8.6-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3f4fbb7f569e69fd9e89d9d9caa57ca42c577c28ed05062f96a8c207594e75b8", size = 2301466, upload-time = "2025-11-03T22:32:57.337Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/790d9002f31580fefd0aec2f373a0f5da99070e04c5e8b1c995d0104f303/libcst-1.8.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:08bd63a8ce674be431260649e70fca1d43f1554f1591eac657f403ff8ef82c7a", size = 2300264, upload-time = "2025-11-03T22:32:58.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/dc3f10e65bab461be5de57850d2910a02c24c3ddb0da28f0e6e4133c3487/libcst-1.8.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e00e275d4ba95d4963431ea3e409aa407566a74ee2bf309a402f84fc744abe47", size = 2408572, upload-time = "2025-11-03T22:33:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3b/35645157a7590891038b077db170d6dd04335cd2e82a63bdaa78c3297dfe/libcst-1.8.6-cp314-cp314-win_amd64.whl", hash = "sha256:fea5c7fa26556eedf277d4f72779c5ede45ac3018650721edd77fd37ccd4a2d4", size = 2193917, upload-time = "2025-11-03T22:33:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a2/1034a9ba7d3e82f2c2afaad84ba5180f601aed676d92b76325797ad60951/libcst-1.8.6-cp314-cp314-win_arm64.whl", hash = "sha256:bb9b4077bdf8857b2483879cbbf70f1073bc255b057ec5aac8a70d901bb838e9", size = 2078748, upload-time = "2025-11-03T22:33:03.707Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a1/30bc61e8719f721a5562f77695e6154e9092d1bdf467aa35d0806dcd6cea/libcst-1.8.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:55ec021a296960c92e5a33b8d93e8ad4182b0eab657021f45262510a58223de1", size = 2188980, upload-time = "2025-11-03T22:33:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/14/c660204532407c5628e3b615015a902ed2d0b884b77714a6bdbe73350910/libcst-1.8.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ba9ab2b012fbd53b36cafd8f4440a6b60e7e487cd8b87428e57336b7f38409a4", size = 2074828, upload-time = "2025-11-03T22:33:06.864Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e2/c497c354943dff644749f177ee9737b09ed811b8fc842b05709a40fe0d1b/libcst-1.8.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c0a0cc80aebd8aa15609dd4d330611cbc05e9b4216bcaeabba7189f99ef07c28", size = 2225568, upload-time = "2025-11-03T22:33:08.354Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/45999676d07bd6d0eefa28109b4f97124db114e92f9e108de42ba46a8028/libcst-1.8.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:42a4f68121e2e9c29f49c97f6154e8527cd31021809cc4a941c7270aa64f41aa", size = 2286523, upload-time = "2025-11-03T22:33:10.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6c/517d8bf57d9f811862f4125358caaf8cd3320a01291b3af08f7b50719db4/libcst-1.8.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a434c521fadaf9680788b50d5c21f4048fa85ed19d7d70bd40549fbaeeecab1", size = 2288044, upload-time = "2025-11-03T22:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ce/24d7d49478ffb61207f229239879845da40a374965874f5ee60f96b02ddb/libcst-1.8.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6a65f844d813ab4ef351443badffa0ae358f98821561d19e18b3190f59e71996", size = 2392605, upload-time = "2025-11-03T22:33:12.962Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c3/829092ead738b71e96a4e96896c96f276976e5a8a58b4473ed813d7c962b/libcst-1.8.6-cp314-cp314t-win_amd64.whl", hash = "sha256:bdb14bc4d4d83a57062fed2c5da93ecb426ff65b0dc02ddf3481040f5f074a82", size = 2181581, upload-time = "2025-11-03T22:33:14.514Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/5d6a790a02eb0d9d36c4aed4f41b277497e6178900b2fa29c35353aa45ed/libcst-1.8.6-cp314-cp314t-win_arm64.whl", hash = "sha256:819c8081e2948635cab60c603e1bbdceccdfe19104a242530ad38a36222cb88f", size = 2065000, upload-time = "2025-11-03T22:33:16.257Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/09/69a0cd1eeb358f03c3ccd79ca22778afc1c1c723158270ad84ce86266eed/libcst-1.8.6-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:cb2679ef532f9fa5be5c5a283b6357cb6e9888a8dd889c4bb2b01845a29d8c0b", size = 2211812, upload-time = "2025-11-03T22:33:17.748Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/38/b965fa7bc4409520404261ce6bdf019e56bed1674b9a68ddfc9e25bc904c/libcst-1.8.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:203ec2a83f259baf686b9526268cd23d048d38be5589594ef143aee50a4faf7e", size = 2093137, upload-time = "2025-11-03T22:33:19.457Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7c/083084b91db049343c49a27279c226f4eb27d28bef4942965386418e643e/libcst-1.8.6-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:6366ab2107425bf934b0c83311177f2a371bfc757ee8c6ad4a602d7cbcc2f363", size = 2237609, upload-time = "2025-11-03T22:33:21.083Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c5/fcf60600a809b9e4cf75e82484a7a9a4bdc80ba3c9939a6a18af3379c6c7/libcst-1.8.6-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:6aa11df6c58812f731172b593fcb485d7ba09ccc3b52fea6c7f26a43377dc748", size = 2301394, upload-time = "2025-11-03T22:33:22.847Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/73/d72942eb3f520bc9444e61a48236694dee3cdc13f6b59179e5288d725b93/libcst-1.8.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:351ab879c2fd20d9cb2844ed1ea3e617ed72854d3d1e2b0880ede9c3eea43ba8", size = 2301816, upload-time = "2025-11-03T22:33:24.295Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5732b20569a434ee3ff96f1b263e6e3f3df70d8dba5cf7c8f7d4b1d6aa41/libcst-1.8.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:98fa1ca321c81fb1f02e5c43f956ca543968cc1a30b264fd8e0a2e1b0b0bf106", size = 2408392, upload-time = "2025-11-03T22:33:25.873Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ad/ecb1275796504a34a9d6d5d4f73bd81cb12930064e98871ad4b4042b82e1/libcst-1.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:25fc7a1303cad7639ad45ec38c06789b4540b7258e9a108924aaa2c132af4aca", size = 2119206, upload-time = "2025-11-03T22:33:27.642Z" },
+    { url = "https://files.pythonhosted.org/packages/94/32/b6521d32a7cde089380efa948e05a7cff95c7ece8f7c36380dd6b4bf2263/libcst-1.8.6-cp39-cp39-win_arm64.whl", hash = "sha256:4d7bbdd35f3abdfb5ac5d1a674923572dab892b126a58da81ff2726102d6ec2e", size = 2001882, upload-time = "2025-11-03T22:33:29.06Z" },
 ]
 
 [[package]]
@@ -847,7 +1041,9 @@ name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
@@ -1171,7 +1367,9 @@ name = "mypy"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -1232,7 +1430,9 @@ name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
 ]
@@ -1258,7 +1458,9 @@ name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
 ]
@@ -1335,7 +1537,9 @@ name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
@@ -1411,7 +1615,9 @@ name = "pytest"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -1465,7 +1671,9 @@ name = "pytest-asyncio"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -1526,7 +1734,9 @@ name = "pytest-mypy-plugins"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -1582,7 +1792,9 @@ name = "pytest-xdist"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
@@ -1666,7 +1878,9 @@ name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
 ]
@@ -1759,6 +1973,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1796,7 +2034,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
 ]
 dependencies = [
     { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2020,7 +2260,9 @@ name = "regex"
 version = "2025.11.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/a9/546676f25e573a4cf00fe8e119b78a37b6a8fe2dc95cda877b30889c9c45/regex-2025.11.3.tar.gz", hash = "sha256:1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01", size = 414669, upload-time = "2025-11-03T21:34:22.089Z" }
@@ -2439,7 +2681,9 @@ name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
@@ -2611,7 +2855,7 @@ name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
     "python_full_version == '3.8.*'",
 ]
@@ -2740,12 +2984,29 @@ name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "mypy-extensions", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

This PR adds a `libcst`-powered codemod to migrate a codebase from Decoy v2 to the Decoy v3 preview

## Change log

- Add `decoy.codemods.migrate` module
- Update migration docs