### PR TITLE
fix: support functools.cached_property

### DIFF
--- a/decoy/next/_internal/inspect.py
+++ b/decoy/next/_internal/inspect.py
@@ -95,21 +95,25 @@ def get_child_spec(spec: object, child_name: str) -> object:
         # falling back to type annotations for attributes
         child_hint = _get_type_hints(spec).get(child_name)
         child_source = inspect.getattr_static(spec, child_name, child_hint)
-        unwrapped_child_source = inspect.unwrap(child_source)
+
+        if isinstance(child_source, property):
+            return _unwrap_type_alias(_get_type_hints(child_source.fget).get("return"))
+
+        if isinstance(child_source, functools.cached_property):
+            return _unwrap_type_alias(_get_type_hints(child_source.func).get("return"))
 
         if isinstance(child_source, staticmethod):
-            return unwrapped_child_source
+            return child_source.__func__
 
-        if isinstance(unwrapped_child_source, property):
-            return _unwrap_type_alias(
-                _get_type_hints(unwrapped_child_source.fget).get("return")
-            )
+        # consume `cls` argument
+        if isinstance(child_source, classmethod):
+            return functools.partial(child_source.__func__, spec)
 
-        # consume `self` and `cls` arguments
-        if inspect.isroutine(unwrapped_child_source):
-            return functools.partial(unwrapped_child_source, None)
+        # consume `self` argument
+        if inspect.isroutine(child_source) and callable(child_source):
+            return functools.partial(child_source, None)
 
-        return _unwrap_type_alias(unwrapped_child_source)
+        return _unwrap_type_alias(child_source)
 
     return None
 

--- a/decoy/spy_core.py
+++ b/decoy/spy_core.py
@@ -133,6 +133,11 @@ class SpyCore:
             if isinstance(child_source, property):
                 child_source = _get_type_hints(child_source.fget).get("return")
 
+            elif hasattr(functools, "cached_property") and isinstance(
+                child_source, functools.cached_property
+            ):
+                child_source = _get_type_hints(child_source.func).get("return")
+
             elif isinstance(child_source, staticmethod):
                 child_source = child_source.__func__
 
@@ -142,7 +147,7 @@ class SpyCore:
 
                 child_source = inspect.unwrap(child_source)
 
-                if inspect.isroutine(child_source):
+                if inspect.isroutine(child_source) and callable(child_source):
                     # consume the `self` argument of the method to ensure proper
                     # signature reporting by wrapping it in a partial
                     child_source = functools.partial(child_source, None)

--- a/tests/legacy/test_mock.py
+++ b/tests/legacy/test_mock.py
@@ -1,6 +1,7 @@
 """Smoke and acceptance tests for main Decoy interface."""
 
 import asyncio
+import functools
 import inspect
 import sys
 from typing import Any
@@ -338,3 +339,34 @@ def test_builtin(decoy: Decoy) -> None:
 
     with pytest.warns(IncorrectCallWarning):
         subject.cancel(message="oops")  # type: ignore[call-arg]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="functools.cached_property added in 3.8"
+)
+def test_cached_property(decoy: Decoy) -> None:
+    """It can mock a cached property."""
+
+    class _Spec:
+        @functools.cached_property
+        def child(self) -> fixtures.SomeClass:
+            raise NotImplementedError()
+
+    subject = decoy.mock(cls=_Spec).child
+
+    assert isinstance(subject, Spy)
+    assert isinstance(subject, fixtures.SomeClass)
+
+
+def test_non_callable_descriptor(decoy: Decoy) -> None:
+    """It doesn't choke on non-callable descriptors."""
+
+    class _NonCallableDescriptor:
+        def __get__(self, *args: Any) -> None: ...
+
+    class _Spec:
+        child = _NonCallableDescriptor()
+
+    subject = decoy.mock(cls=_Spec).child
+
+    assert isinstance(subject, Spy)

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import sys
 from typing import Any
@@ -331,6 +332,20 @@ def test_create_untyped_property_mock(decoy: Decoy) -> None:
     assert repr(subject) == "<Decoy mock `tests.fixtures.SomeClass.mystery_property`>"
 
 
+def test_create_cached_property_mock(decoy: Decoy) -> None:
+    """It can mock a cached property."""
+
+    class _Spec:
+        @functools.cached_property
+        def child(self) -> fixtures.SomeClass:
+            raise NotImplementedError()
+
+    subject = decoy.mock(cls=_Spec).child
+
+    assert isinstance(subject, Mock)
+    assert isinstance(subject, fixtures.SomeClass)
+
+
 def test_func_bad_call(decoy: Decoy) -> None:
     """It raises an IncorrectCallWarning if call is bad."""
     subject = decoy.mock(func=fixtures.some_func)
@@ -374,3 +389,17 @@ def test_builtin(decoy: Decoy) -> None:
 
     with pytest.raises(errors.SignatureMismatchError):
         subject.cancel(message="oops")  # type: ignore[call-arg]
+
+
+def test_non_callable_descriptor(decoy: Decoy) -> None:
+    """It doesn't choke on non-callable descriptors."""
+
+    class _NonCallableDescriptor:
+        def __get__(self, *args: Any) -> None: ...
+
+    class _Spec:
+        child = _NonCallableDescriptor()
+
+    subject = decoy.mock(cls=_Spec).child
+
+    assert isinstance(subject, Mock)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mock handling for functools.cached_property so mocked cached properties resolve to the annotated return type.
  * Fixed behavior for non-callable descriptor attributes so accessing them on mocks no longer fails.
  * Improved handling of bound and routine-like attributes so mocked callables report signatures and binding consistently.

* **Tests**
  * Added tests covering functools.cached_property mocking scenarios.
  * Added tests for non-callable descriptor behavior on mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->