### PR TITLE
fix(v3): avoid spurious miscalled stub warnings

### DIFF
--- a/decoy/next/_internal/compare.py
+++ b/decoy/next/_internal/compare.py
@@ -12,6 +12,18 @@ from .values import (
 )
 
 
+def is_miscalled_stub_event(
+    entry: EventEntry,
+    behaviors: list[BehaviorEntry],
+    matched_event_indices: set[int],
+) -> bool:
+    """Return True if this call event should trigger a MiscalledStubWarning."""
+    return (
+        any(is_event_from_mock(entry, b.mock) for b in behaviors)
+        and entry.order not in matched_event_indices
+    )
+
+
 def is_event_from_mock(event_entry: EventEntry, mock: MockInfo) -> bool:
     return mock.id == event_entry.mock.id
 

--- a/decoy/next/_internal/decoy.py
+++ b/decoy/next/_internal/decoy.py
@@ -3,6 +3,7 @@ import contextlib
 from typing import Any, Callable, Literal, TypeVar, overload
 
 from ...errors import NotAMockError, VerifyOrderError
+from ...warnings import MiscalledStubWarning
 from .inspect import (
     ensure_spec,
     ensure_spec_name,
@@ -11,9 +12,10 @@ from .inspect import (
 )
 from .mock import AsyncMock, Mock, create_mock, ensure_mock
 from .state import DecoyState
-from .stringify import stringify_verify_order_failure
+from .stringify import stringify_miscalled_stub, stringify_verify_order_failure
 from .values import MatchOptions
 from .verify import Verify
+from .warn import warn
 from .when import When
 
 ClassT = TypeVar("ClassT")
@@ -232,4 +234,13 @@ class Decoy:
 
     def reset(self) -> None:
         """Reset the decoy instance."""
+        for miscalled in self._state.get_miscalled_stubs():
+            message = stringify_miscalled_stub(
+                miscalled.mock_name,
+                miscalled.expected_events,
+                miscalled.all_events,
+                miscalled.event,
+            )
+            warn(MiscalledStubWarning(message), miscalled.call_site)
+
         self._state.reset()

--- a/decoy/next/_internal/inspect.py
+++ b/decoy/next/_internal/inspect.py
@@ -177,7 +177,7 @@ def get_call_site() -> CallSite | None:
     frame = inspect.currentframe()
     while frame is not None:
         module: str = frame.f_globals.get("__name__", "")
-        if not module.startswith("decoy"):
+        if not module.startswith("decoy."):
             return CallSite(frame.f_code.co_filename, frame.f_lineno, module)
         frame = frame.f_back
 

--- a/decoy/next/_internal/inspect.py
+++ b/decoy/next/_internal/inspect.py
@@ -19,6 +19,7 @@ from ...errors import (
     SignatureMismatchError,
     ThenDoActionNotCallableError,
 )
+from .values import CallSite
 
 
 class BoundArguments(NamedTuple):
@@ -169,6 +170,19 @@ def bind_args(
         raise SignatureMismatchError(error) from None
 
     return BoundArguments(bound_args.args, bound_args.kwargs)
+
+
+def get_call_site() -> CallSite | None:
+    """Walk frames upward to find the first frame outside the decoy package."""
+    frame = inspect.currentframe()
+    while frame is not None:
+        module: str = frame.f_globals.get("__name__", "")
+        if not module.startswith("decoy"):
+            return CallSite(frame.f_code.co_filename, frame.f_lineno, module)
+        frame = frame.f_back
+
+    # In CPython, we'll always have a call site
+    return None  # pragma: no cover
 
 
 def get_func_name(func: Callable[..., object]) -> str:

--- a/decoy/next/_internal/mock.py
+++ b/decoy/next/_internal/mock.py
@@ -1,12 +1,11 @@
 import inspect
-import warnings
 from types import TracebackType
 from typing import Any, cast
 
-from ...warnings import MiscalledStubWarning
 from .inspect import (
     bind_args,
     get_awaitable_value,
+    get_call_site,
     get_child_spec,
     get_method_class,
     get_signature,
@@ -15,7 +14,6 @@ from .inspect import (
     is_magic_attribute,
 )
 from .state import DecoyState
-from .stringify import stringify_miscalled_stub
 from .values import AttributeEvent, CallEvent, EventState, MockInfo
 
 
@@ -48,21 +46,12 @@ class MockInternals:
     def call(self, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
         bound_args = bind_args(self.info.signature, args, kwargs)
         event = CallEvent(bound_args.args, bound_args.kwargs)
-        behavior = self.state.use_call_behavior(
+        return self.state.use_call_behavior(
             mock=self.info,
             event=event,
             event_state=self.event_state,
+            call_site=get_call_site(),
         )
-
-        if not behavior.is_found and behavior.expected_events:
-            message = stringify_miscalled_stub(
-                self.name,
-                behavior.expected_events,
-                event,
-            )
-            warnings.warn(MiscalledStubWarning(message), stacklevel=3)
-
-        return behavior.return_value
 
     def get_child(self, name: str, is_async: bool = False) -> "Mock":
         if name in self.children:

--- a/decoy/next/_internal/state.py
+++ b/decoy/next/_internal/state.py
@@ -10,6 +10,7 @@ from .compare import (
     is_matching_behavior,
     is_matching_count,
     is_matching_event,
+    is_miscalled_stub_event,
     is_redundant_verify,
     is_successful_verify,
     is_successful_verify_order,
@@ -22,19 +23,15 @@ from .values import (
     Behavior,
     BehaviorEntry,
     CallEvent,
+    CallSite,
     Event,
     EventEntry,
     EventMatcher,
     EventState,
+    MiscalledStub,
     MockInfo,
     VerificationEntry,
 )
-
-
-class BehaviorResult(NamedTuple):
-    is_found: bool
-    return_value: object
-    expected_events: list[Event]
 
 
 class VerificationResult(NamedTuple):
@@ -58,11 +55,12 @@ class DecoyState:
         self._behaviors: list[BehaviorEntry] = []
         self._behavior_usage_by_index: dict[int, int] = collections.defaultdict(int)
         self._attribute_mocks_by_id: dict[int, object] = {}
+        self._matched_event_indices: set[int] = set()
 
     def _consume_behavior(
         self,
         event_entry: EventEntry,
-    ) -> tuple[Behavior | None, list[Event], bool]:
+    ) -> Behavior | None:
         mock_behaviors = [
             behavior
             for behavior in self._behaviors
@@ -73,29 +71,29 @@ class DecoyState:
             for behavior in mock_behaviors
             if is_matching_event(event_entry, behavior.matcher)
         ]
-        expected_events = [behavior.matcher.event for behavior in mock_behaviors]
 
         for behavior_entry in reversed(matched_behaviors):
             usage_count = self._behavior_usage_by_index[behavior_entry.order]
 
             if is_matching_count(usage_count, behavior_entry.matcher):
                 self._behavior_usage_by_index[behavior_entry.order] = usage_count + 1
-                return behavior_entry.behavior, expected_events, True
+                self._matched_event_indices.add(event_entry.order)
+                return behavior_entry.behavior
 
-        return None, expected_events, len(matched_behaviors) > 0
+        return None
 
     def _use_behavior(
         self,
         event_entry: EventEntry,
         default_return_value: object = None,
-    ) -> BehaviorResult:
+    ) -> object:
         event = event_entry.event
-        behavior, expected_events, is_found = self._consume_behavior(event_entry)
+        behavior = self._consume_behavior(event_entry)
 
         if behavior is None:
-            return_value = default_return_value
+            return default_return_value
 
-        elif behavior.error:
+        if behavior.error:
             raise behavior.error
 
         elif behavior.action:
@@ -109,27 +107,21 @@ class DecoyState:
                 args = ()
                 kwargs = {}
 
-            return_value = behavior.action(*args, **kwargs)
+            return behavior.action(*args, **kwargs)
 
         elif behavior.context is not MISSING:
-            return_value = contextlib.nullcontext(behavior.context)
+            return contextlib.nullcontext(behavior.context)
 
-        else:
-            return_value = behavior.return_value
-
-        return BehaviorResult(
-            is_found=is_found,
-            expected_events=expected_events,
-            return_value=return_value,
-        )
+        return behavior.return_value
 
     def _add_event(
         self,
         mock: MockInfo,
         event: Event,
         event_state: EventState,
+        call_site: CallSite | None = None,
     ) -> EventEntry:
-        event_entry = EventEntry(mock, event, event_state, len(self._events))
+        event_entry = EventEntry(mock, event, event_state, len(self._events), call_site)
 
         self._events.append(event_entry)
 
@@ -150,11 +142,11 @@ class DecoyState:
         mock: MockInfo,
         event: CallEvent,
         event_state: EventState,
-    ) -> BehaviorResult:
-        event_entry = self._add_event(mock, event, event_state)
-        behavior_result = self._use_behavior(event_entry)
+        call_site: CallSite | None = None,
+    ) -> object:
+        event_entry = self._add_event(mock, event, event_state, call_site)
 
-        return behavior_result
+        return self._use_behavior(event_entry)
 
     def use_attribute_behavior(
         self,
@@ -176,9 +168,7 @@ class DecoyState:
         elif event.type == AttributeEventType.DELETE:
             self._attribute_mocks_by_id.pop(mock.id, None)
 
-        behavior_result = self._use_behavior(event_entry, default_return_value)
-
-        return behavior_result.return_value
+        return self._use_behavior(event_entry, default_return_value)
 
     def use_verification(
         self,
@@ -198,6 +188,8 @@ class DecoyState:
         verification = VerificationEntry(mock, matcher, matching_events)
         is_success = is_successful_verify(verification)
         is_redundant = is_redundant_verify(verification, self._behaviors)
+
+        self._matched_event_indices.update(e.order for e in matching_events)
 
         if is_success and self._order_verification:
             self._order_verification.verifications.append(verification)
@@ -258,9 +250,37 @@ class DecoyState:
             result.all_events,
         )
 
+    def get_miscalled_stubs(self) -> list[MiscalledStub]:
+        return [
+            MiscalledStub(
+                mock_name=entry.mock.name,
+                event=entry.event,
+                all_events=[
+                    e.event
+                    for e in self._events
+                    if isinstance(e.event, CallEvent)
+                    and is_event_from_mock(e, entry.mock)
+                ],
+                expected_events=[
+                    b.matcher.event
+                    for b in self._behaviors
+                    if is_event_from_mock(entry, b.mock)
+                ],
+                call_site=entry.call_site,
+            )
+            for entry in self._events
+            if isinstance(entry.event, CallEvent)
+            and is_miscalled_stub_event(
+                entry,
+                self._behaviors,
+                self._matched_event_indices,
+            )
+        ]
+
     def reset(self) -> None:
         self._events.clear()
         self._behaviors.clear()
         self._behavior_usage_by_index.clear()
         self._attribute_mocks_by_id.clear()
+        self._matched_event_indices.clear()
         self._order_verification = None

--- a/decoy/next/_internal/stringify.py
+++ b/decoy/next/_internal/stringify.py
@@ -1,6 +1,7 @@
 """Message string generation."""
 
 import os
+import reprlib
 from typing import Iterable
 
 from .values import (
@@ -50,14 +51,16 @@ def stringify_verify_order_failure(
 def stringify_miscalled_stub(
     name: str,
     expected_events: list[Event],
-    actual_event: CallEvent,
+    all_events: list[CallEvent],
+    miscalled_event: CallEvent,
 ) -> str:
     return _join_lines(
         "Mock was called but no matching `when` found.",
+        f"\t{_stringify_event(name, miscalled_event)}",
         f"Found {_count(len(expected_events), 'stubbing')}:",
         _stringify_event_list(name, expected_events),
-        "Found 1 call:",
-        f"1.\t{_stringify_event(name, actual_event)}",
+        f"Found {_count(len(all_events), 'call')}:",
+        _stringify_event_list(name, all_events),
     )
 
 
@@ -76,7 +79,6 @@ def stringify_redundant_verify(
 def _stringify_event(
     mock_name: str,
     event: Event,
-    ignore_extra_args: bool = False,
 ) -> str:
     """Stringify a call to something human readable."""
     if isinstance(event, AttributeEvent):
@@ -89,13 +91,12 @@ def _stringify_event(
         return mock_name  # pragma: no cover
 
     else:
-        args_list = [repr(arg) for arg in event.args]
-        kwargs_list = [f"{key}={val!r}" for key, val in event.kwargs.items()]
-        extra_args_msg = (
-            " - ignoring unspecified arguments" if ignore_extra_args else ""
-        )
+        args_list = [reprlib.repr(arg) for arg in event.args]
+        kwargs_list = [
+            f"{key}={reprlib.repr(val)}" for key, val in event.kwargs.items()
+        ]
 
-        return f"{mock_name}({', '.join(args_list + kwargs_list)}){extra_args_msg}"
+        return f"{mock_name}({', '.join(args_list + kwargs_list)})"
 
 
 def _stringify_event_list(mock_name: str, events: Iterable[Event]) -> str:

--- a/decoy/next/_internal/values.py
+++ b/decoy/next/_internal/values.py
@@ -76,11 +76,20 @@ class MockInfo(NamedTuple):
     signature: inspect.Signature | None
 
 
+class CallSite(NamedTuple):
+    """Source location of a call to a mock, captured at call time."""
+
+    filename: str
+    lineno: int
+    module: str
+
+
 class EventEntry(NamedTuple):
     mock: MockInfo
     event: Event
     state: EventState
     order: int
+    call_site: CallSite | None = None
 
 
 class BehaviorEntry(NamedTuple):
@@ -94,3 +103,11 @@ class VerificationEntry(NamedTuple):
     mock: MockInfo
     matcher: EventMatcher
     matching_events: list[EventEntry]
+
+
+class MiscalledStub(NamedTuple):
+    mock_name: str
+    event: CallEvent
+    all_events: list[CallEvent]
+    expected_events: list[Event]
+    call_site: CallSite | None

--- a/decoy/next/_internal/verify.py
+++ b/decoy/next/_internal/verify.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Callable, Generic, ParamSpec, TypeVar
 
 from ...errors import VerifyError
@@ -14,6 +13,7 @@ from .values import (
     MatchOptions,
     MockInfo,
 )
+from .warn import warn
 
 SpecT = TypeVar("SpecT")
 ParamsT = ParamSpec("ParamsT")
@@ -47,7 +47,7 @@ class Verify(Generic[SpecT]):
 
         if result.is_redundant:
             message = stringify_redundant_verify(self._mock.name, expected)
-            warnings.warn(RedundantVerifyWarning(message), stacklevel=3)
+            warn(RedundantVerifyWarning(message))
 
     def called_with(
         self: "Verify[Callable[ParamsT, Any]]",

--- a/decoy/next/_internal/warn.py
+++ b/decoy/next/_internal/warn.py
@@ -1,0 +1,18 @@
+import warnings
+
+from ...warnings import DecoyWarning
+from .values import CallSite
+
+
+def warn(warning: DecoyWarning, site: CallSite | None = None) -> None:
+    """Issue a warning, pointing at the captured call site if available."""
+    if site is not None:
+        warnings.warn_explicit(
+            warning,
+            category=None,
+            filename=site.filename,
+            lineno=site.lineno,
+            module=site.module,
+        )
+    else:
+        warnings.warn(warning, stacklevel=4)

--- a/decoy/warnings.py
+++ b/decoy/warnings.py
@@ -15,8 +15,6 @@ from .stringify import count, stringify_call, stringify_error_message
 class DecoyWarning(UserWarning):
     """Base class for Decoy warnings."""
 
-    pass
-
 
 class MiscalledStubWarning(DecoyWarning):
     """A warning when a configured Stub is called with non-matching arguments.

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -105,3 +105,24 @@ def test_reset_miscalled_stub_warning_call_site() -> None:
 
     assert log[0].filename == "<test_callsite>"
     assert log[0].lineno == 5  # subject("goodbye") is line 5 in the script
+
+
+def test_reset_warning_ignores_decoy_lookalike_module() -> None:
+    """A caller in a 'decoy'-prefixed module is still reported as the call site."""
+    script = textwrap.dedent("""
+        from decoy.next import Decoy
+        decoy = Decoy()
+        subject = decoy.mock(name="subject")
+        decoy.when(subject).called_with("hello").then_return("world")
+        subject("goodbye")
+        decoy.reset()
+    """).strip()
+
+    module_globals = {"__name__": "decoytools"}
+
+    with stdlib_warnings.catch_warnings(record=True) as log:
+        stdlib_warnings.simplefilter("always")
+        exec(compile(script, filename="<decoytools>", mode="exec"), module_globals)
+
+    assert log[0].filename == "<decoytools>"
+    assert log[0].lineno == 5  # subject("goodbye") is line 5 in the script

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,0 +1,107 @@
+"""Tests for Decoy.reset."""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+import warnings as stdlib_warnings
+
+import pytest
+
+from decoy import warnings
+
+if sys.version_info >= (3, 10):
+    from decoy.next import Decoy
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="v3 preview only supports Python >= 3.10",
+)
+
+
+def test_reset_miscalled_stub_warning(decoy: Decoy) -> None:
+    """It raises a MiscalledStubWarning at reset if calls don't match stubbings."""
+    subject = decoy.mock(name="subject")
+
+    decoy.when(subject).called_with("hello").then_return("hello world")
+    subject("goodbye")
+
+    with pytest.warns(warnings.MiscalledStubWarning) as warnings_log:
+        decoy.reset()
+
+    assert str(warnings_log[0].message) == os.linesep.join(
+        [
+            "Mock was called but no matching `when` found.",
+            "\tsubject('goodbye')",
+            "Found 1 stubbing:",
+            "1.\tsubject('hello')",
+            "Found 1 call:",
+            "1.\tsubject('goodbye')",
+        ]
+    )
+
+
+def test_reset_no_warning_without_stubs(decoy: Decoy) -> None:
+    """It does not warn if the mock has no stubs configured."""
+    subject = decoy.mock(name="subject")
+    subject("anything")
+
+    with stdlib_warnings.catch_warnings():
+        stdlib_warnings.simplefilter("error", warnings.MiscalledStubWarning)
+        decoy.reset()
+
+
+def test_reset_no_warning_when_call_matches(decoy: Decoy) -> None:
+    """It does not warn if every call matched a stub."""
+    subject = decoy.mock(name="subject")
+    decoy.when(subject).called_with("hello").then_return("world")
+    subject("hello")
+
+    with stdlib_warnings.catch_warnings():
+        stdlib_warnings.simplefilter("error", warnings.MiscalledStubWarning)
+        decoy.reset()
+
+
+def test_reset_no_warning_when_verified(decoy: Decoy) -> None:
+    """It does not warn if a non-matching call was later verified."""
+    subject = decoy.mock(name="subject")
+    decoy.when(subject).called_with("hello").then_return("world")
+    subject("goodbye")
+    decoy.verify(subject).called_with("goodbye")
+
+    with stdlib_warnings.catch_warnings():
+        stdlib_warnings.simplefilter("error", warnings.MiscalledStubWarning)
+        decoy.reset()
+
+
+def test_reset_warning_verify_ordering(decoy: Decoy) -> None:
+    """It still warns for a call that occurs after a verify, not covered by it."""
+    subject = decoy.mock(name="subject")
+    decoy.when(subject).called_with("hello").then_return("world")
+
+    subject("goodbye")
+    decoy.verify(subject).called_with("goodbye")
+    subject("goodbye")  # second call — not covered by the verify above
+
+    with pytest.warns(warnings.MiscalledStubWarning):
+        decoy.reset()
+
+
+def test_reset_miscalled_stub_warning_call_site() -> None:
+    """Warning call site points to the actual call, not reset."""
+    script = textwrap.dedent("""
+        from decoy.next import Decoy
+        decoy = Decoy()
+        subject = decoy.mock(name="subject")
+        decoy.when(subject).called_with("hello").then_return("world")
+        subject("goodbye")
+        decoy.reset()
+    """).strip()
+
+    with stdlib_warnings.catch_warnings(record=True) as log:
+        stdlib_warnings.simplefilter("always")
+        exec(compile(script, filename="<test_callsite>", mode="exec"))
+
+    assert log[0].filename == "<test_callsite>"
+    assert log[0].lineno == 5  # subject("goodbye") is line 5 in the script

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import collections.abc
 import contextlib
-import os
 import sys
 from typing import Any
 
 import pytest
 
-from decoy import errors, warnings
+from decoy import errors
 
 from . import fixtures
 
@@ -230,26 +229,6 @@ def test_when_signature_wrong_in_stubbing(decoy: Decoy) -> None:
         decoy.when(subject).called_with("hello", "world")  # type: ignore[call-arg]
 
 
-def test_when_no_match_warning(decoy: Decoy) -> None:
-    """It raises a MiscalledStubWarning if calls don't match stubbings."""
-    subject = decoy.mock(name="subject")
-
-    decoy.when(subject).called_with("hello").then_return("hello world")
-
-    with pytest.warns(warnings.MiscalledStubWarning) as warnings_log:
-        subject("goodbye")
-
-    assert str(warnings_log[0].message) == os.linesep.join(
-        [
-            "Mock was called but no matching `when` found.",
-            "Found 1 stubbing:",
-            "1.\tsubject('hello')",
-            "Found 1 call:",
-            "1.\tsubject('goodbye')",
-        ]
-    )
-
-
 def test_when_ignore_extra_args(decoy: Decoy) -> None:
     """It ignores extra args in the call."""
 
@@ -274,6 +253,7 @@ def test_when_ignore_extra_args_signature(decoy: Decoy) -> None:
         decoy.when(subject).called_with(not_a="hello")  # type: ignore[call-arg]
 
 
+@pytest.mark.filterwarnings("ignore::decoy.warnings.MiscalledStubWarning")
 def test_when_times(decoy: Decoy) -> None:
     """It returns a value a given number of times."""
     subject = decoy.mock(name="subject")


### PR DESCRIPTION
This PR reverts v3's `MiscalledStubWarning` behavior back to the v2 behavior of checking for miscalled stubs a `reset` time, instead of warning at mock call time. Even without rehearsals, a given mock does not have enough information at call time to determine if it was miscalled; e.g. it may be later checked in a `verify` call.

While using `reset` is the more reliable option, I didn't want to give up throwing the warning at the mock's call site, so this PR also switches to using [`warnings.warn_explicit`](https://docs.python.org/3/library/warnings.html#warnings.warn_explicit) and site capture during mock calls to throw warnings in the proper location